### PR TITLE
fix: Add missing mcp dependency to resolve FastMCP import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-requests>=2.25.0 
+requests>=2.25.0
+mcp>=1.0.0


### PR DESCRIPTION
## Problem
The NetBox MCP server currently fails to start due to a missing dependency, resulting in the following import error:

> ❌ **import "mcp.server.fastmcp" could not be resolved**

This prevents the server from being used as intended and blocks any MCP functionality.

## Solution
Added the missing `mcp>=1.0.0` dependency to `requirements.txt` to resolve the import error for the `FastMCP` class from `mcp.server.fastmcp`.

## Changes
- **requirements.txt**: Added `mcp>=1.0.0` dependency

## Testing
After installing the updated requirements, the import error is resolved and the server can be imported successfully.

## Impact
- ✅ Fixes server startup issues
- ✅ Enables proper MCP functionality 
- ✅ No breaking changes
- ✅ Minimal dependency addition

This is a small fix that enables the basic functionality of the NetBox MCP server.