### PR TITLE
Update FastMCP log level to use environment variable

### DIFF
--- a/server.py
+++ b/server.py
@@ -97,7 +97,7 @@ NETBOX_OBJECT_TYPES = {
     "webhooks": "extras/webhooks",
 }
 
-mcp = FastMCP("NetBox", log_level="DEBUG")
+mcp = FastMCP("NetBox", log_level=os.getenv("LOG_LEVEL", "INFO"))
 netbox = None
 
 @mcp.tool()


### PR DESCRIPTION
That way will be better, we can always manually set the `LOG_LEVEL` to `DEBUG`, in the production case the default debug enabled fills up the logs terribly.