### PR TITLE
Update mcpServers README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install -e .
 
 ```json
 {
-  "mcpServers": {
+    "mcpServers": {
         "netbox": {
             "command": "uv",
             "args": [
@@ -45,6 +45,7 @@ pip install -e .
                 "NETBOX_TOKEN": "<your-api-token>"
             }
         }
+    }
 }
 ```
 > On Windows, use full, escaped path to your instance, such as `C:\\Users\\myuser\\.local\\bin\\uv` and `C:\\Users\\myuser\\netbox-mcp-server`. 


### PR DESCRIPTION
Quick add of a missing bracket on the README mcpServers config example. 