### PR TITLE
feat(tools): add support for ordering parameter to netbox_get_objects

### DIFF
--- a/server.py
+++ b/server.py
@@ -271,6 +271,7 @@ def netbox_get_objects(
     fields: list[str] | None = None,
     limit: Annotated[int, Field(default=5, ge=1, le=100)] = 5,
     offset: Annotated[int, Field(default=0, ge=0)] = 0,
+    ordering: str | list[str] | None = None,
 ):
     """
     Get objects from NetBox based on their type and filters
@@ -311,6 +312,17 @@ def netbox_get_objects(
 
         offset: Skip this many results for pagination (default 0)
                 Example: offset=0 (page 1), offset=5 (page 2), offset=10 (page 3)
+
+        ordering: Fields used to determine sort order of results.
+                  Field names may be prefixed with '-' to invert the sort order.
+                  Multiple fields may be specified with a list of strings.
+
+                  Examples:
+                  - 'name' (alphabetical by name)
+                  - '-id' (ordered by ID descending)
+                  - ['facility', '-name'] (by facility, then by name descending)
+                  - None, '' or [] (default NetBox ordering)
+
 
     Returns:
         Paginated response dict with the following structure:
@@ -431,6 +443,12 @@ def netbox_get_objects(
 
     if fields:
         params["fields"] = ",".join(fields)
+
+    if ordering:
+        if isinstance(ordering, list):
+            ordering = ",".join(ordering)
+        if ordering.strip() != "":
+            params["ordering"] = ordering
 
     # Make API call
     return netbox.get(endpoint, params=params)

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -1,0 +1,104 @@
+"""Tests for ordering parameter validation and behavior."""
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from server import netbox_get_objects
+
+
+def test_ordering_rejects_invalid_types():
+    """Ordering parameter should reject non-string/non-list types."""
+    ordering_annotation = netbox_get_objects.fn.__annotations__["ordering"]
+    adapter = TypeAdapter(ordering_annotation)
+
+    with pytest.raises(ValidationError):
+        adapter.validate_python(123)
+
+    with pytest.raises(ValidationError):
+        adapter.validate_python({"field": "name"})
+
+    with pytest.raises(ValidationError):
+        adapter.validate_python(["name", 123])
+
+@patch("server.netbox")
+def test_ordering_none_omits_parameter(mock_netbox):
+    """When ordering=None, should not include ordering in API params."""
+    mock_netbox.get.return_value = {"count": 0, "results": [], "next": None, "previous": None}
+
+    netbox_get_objects.fn(object_type="sites", filters={}, ordering=None)
+
+    call_args = mock_netbox.get.call_args
+    params = call_args[1]["params"]
+
+    # ordering should not be in params when None
+    assert "ordering" not in params
+
+
+@patch("server.netbox")
+def test_ordering_empty_string_omits_parameter(mock_netbox):
+    """When ordering='', should not include ordering in API params."""
+    mock_netbox.get.return_value = {"count": 0, "results": [], "next": None, "previous": None}
+
+    netbox_get_objects.fn(object_type="sites", filters={}, ordering="")
+
+    call_args = mock_netbox.get.call_args
+    params = call_args[1]["params"]
+
+    # ordering should not be in params when empty string
+    assert "ordering" not in params
+
+
+@patch("server.netbox")
+def test_ordering_single_field_ascending(mock_netbox):
+    """When ordering='name', should pass 'name' to API params."""
+    mock_netbox.get.return_value = {"count": 0, "results": [], "next": None, "previous": None}
+
+    netbox_get_objects.fn(object_type="sites", filters={}, ordering="name")
+
+    call_args = mock_netbox.get.call_args
+    params = call_args[1]["params"]
+
+    assert params["ordering"] == "name"
+
+
+@patch("server.netbox")
+def test_ordering_single_field_descending(mock_netbox):
+    """When ordering='-id', should pass '-id' to API params."""
+    mock_netbox.get.return_value = {"count": 0, "results": [], "next": None, "previous": None}
+
+    netbox_get_objects.fn(object_type="sites", filters={}, ordering="-id")
+
+    call_args = mock_netbox.get.call_args
+    params = call_args[1]["params"]
+
+    assert params["ordering"] == "-id"
+
+
+@patch("server.netbox")
+def test_ordering_multiple_fields_as_list(mock_netbox):
+    """When ordering=['facility', '-name'], should pass comma-separated string."""
+    mock_netbox.get.return_value = {"count": 0, "results": [], "next": None, "previous": None}
+
+    netbox_get_objects.fn(object_type="sites", filters={}, ordering=["facility", "-name"])
+
+    call_args = mock_netbox.get.call_args
+    params = call_args[1]["params"]
+
+    # List should be converted to comma-separated string
+    assert params["ordering"] == "facility,-name"
+
+
+@patch("server.netbox")
+def test_ordering_empty_list_omits_parameter(mock_netbox):
+    """When ordering=[], should not include ordering in API params."""
+    mock_netbox.get.return_value = {"count": 0, "results": [], "next": None, "previous": None}
+
+    netbox_get_objects.fn(object_type="sites", filters={}, ordering=[])
+
+    call_args = mock_netbox.get.call_args
+    params = call_args[1]["params"]
+
+    # Empty list should result in empty string, which should be omitted
+    assert "ordering" not in params

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -5,7 +5,7 @@ import inspect
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
-from server import netbox_get_objects, netbox_get_object_by_id
+from server import netbox_get_objects
 
 
 def test_limit_validation_rejects_values_over_100():


### PR DESCRIPTION
Allows the `netbox_get_objects` tool to accept an `ordering` parameter to 
determine result order.