### PR TITLE
Feature proposal: plugin discovery for more object-types in MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a simple read-only [Model Context Protocol](https://modelcontextprotocol
 | get_object_by_id | Gets detailed information about a specific NetBox object by its ID |
 | get_changelogs | Retrieves change history records (audit trail) based on filters |
 
-> Note: the set of supported object types is explicitly defined and limited to the core NetBox objects for now, and won't work with object types from plugins.
+> Note: Core NetBox object types are always available. Plugin object types can be auto-discovered — see [Plugin Object Type Discovery](#plugin-object-type-discovery).
 
 ## Usage
 
@@ -170,6 +170,7 @@ The server supports multiple configuration sources with the following precedence
 | `HOST` | String | `127.0.0.1` | If HTTP | Host address for HTTP server |
 | `PORT` | Integer | `8000` | If HTTP | Port for HTTP server |
 | `VERIFY_SSL` | Boolean | `true` | No | Whether to verify SSL certificates |
+| `ENABLE_PLUGIN_DISCOVERY` | Boolean | `false` | No | Auto-discover plugin object types at startup |
 | `LOG_LEVEL` | `DEBUG` \| `INFO` \| `WARNING` \| `ERROR` \| `CRITICAL` | `INFO` | No | Logging verbosity |
 
 ### Transport Examples
@@ -234,6 +235,9 @@ TRANSPORT=stdio
 
 # Security (optional, defaults to true)
 VERIFY_SSL=true
+
+# Plugin Discovery (optional, defaults to false)
+# ENABLE_PLUGIN_DISCOVERY=true
 
 # Logging (optional, defaults to INFO)
 LOG_LEVEL=INFO
@@ -307,6 +311,53 @@ docker run --rm \
 ```
 
 The server will be accessible at `http://localhost:8000/mcp` for MCP clients. You can connect to it using your preferred method.
+
+## Plugin Object Type Discovery
+
+By default, only core NetBox object types are available. If your NetBox instance has plugins installed (e.g., `netbox-dns`, `netbox-inventory`), you can enable automatic discovery to make their object types available as well.
+
+### Enabling Discovery
+
+Set the `ENABLE_PLUGIN_DISCOVERY` environment variable or use the `--enable-plugin-discovery` CLI flag:
+
+```bash
+# Via environment variable
+ENABLE_PLUGIN_DISCOVERY=true uv run netbox-mcp-server
+
+# Via CLI flag
+uv run netbox-mcp-server --enable-plugin-discovery
+
+# In Claude Desktop config
+{
+    "mcpServers": {
+        "netbox": {
+            "command": "uv",
+            "args": ["--directory", "/path/to/netbox-mcp-server", "run", "netbox-mcp-server"],
+            "env": {
+                "NETBOX_URL": "https://netbox.example.com/",
+                "NETBOX_TOKEN": "<your-api-token>",
+                "ENABLE_PLUGIN_DISCOVERY": "true"
+            }
+        }
+    }
+}
+```
+
+### How It Works
+
+At startup, the server queries NetBox's `core/object-types` API endpoint (with `extras/object-types` fallback for NetBox < 4.4) to find all installed plugin models that have REST API endpoints. These are merged into the runtime type registry alongside the core types.
+
+Discovered plugin types use the `app_label.model` naming convention (e.g., `netbox_dns.zone`, `netbox_inventory.asset`) and work with all existing tools (`netbox_get_objects`, `netbox_get_object_by_id`, `netbox_search_objects`).
+
+### Requirements
+
+- NetBox 4.2 or later
+- API token must have read access to the object-types endpoint
+- Plugin models must expose a REST API endpoint to be discovered
+
+### Failure Behavior
+
+If discovery fails for any reason (network error, insufficient permissions, unsupported NetBox version), the server logs a warning and continues with core types only. This ensures the server always starts successfully regardless of discovery outcome.
 
 ## Development
 

--- a/src/netbox_mcp_server/config.py
+++ b/src/netbox_mcp_server/config.py
@@ -34,6 +34,10 @@ class Settings(BaseSettings):
     port: int = 8000
     """Port to bind HTTP server (only used when transport='http')"""
 
+    # ===== Plugin Discovery Settings =====
+    enable_plugin_discovery: bool = False
+    """Whether to auto-discover plugin object types from NetBox at startup"""
+
     # ===== Security Settings =====
     verify_ssl: bool = True
     """Whether to verify SSL certificates when connecting to NetBox"""
@@ -90,6 +94,7 @@ class Settings(BaseSettings):
             "host": self.host if self.transport == "http" else "N/A",
             "port": self.port if self.transport == "http" else "N/A",
             "verify_ssl": self.verify_ssl,
+            "enable_plugin_discovery": self.enable_plugin_discovery,
             "log_level": self.log_level,
         }
 

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -1,8 +1,10 @@
 import argparse
+import asyncio
 import logging
 import sys
 from typing import Annotated, Any
 
+import httpx
 from fastmcp import FastMCP
 from pydantic import Field
 
@@ -69,6 +71,15 @@ def parse_cli_args() -> dict[str, Any]:
         help="Disable SSL certificate verification (not recommended)",
     )
 
+    # Plugin discovery settings
+    parser.add_argument(
+        "--enable-plugin-discovery",
+        action="store_true",
+        default=None,
+        dest="enable_plugin_discovery",
+        help="Auto-discover plugin object types from NetBox at startup",
+    )
+
     # Observability settings
     parser.add_argument(
         "--log-level",
@@ -92,6 +103,8 @@ def parse_cli_args() -> dict[str, Any]:
         overlay["port"] = args.port
     if args.verify_ssl is not None:
         overlay["verify_ssl"] = args.verify_ssl
+    if args.enable_plugin_discovery is not None:
+        overlay["enable_plugin_discovery"] = args.enable_plugin_discovery
     if args.log_level is not None:
         overlay["log_level"] = args.log_level
 
@@ -520,6 +533,116 @@ def _get_endpoint_info(object_type: str) -> tuple[str, str | None]:
     return type_info["endpoint"], type_info.get("fallback_endpoint")
 
 
+def discover_plugin_types(client: NetBoxRestClient) -> dict[str, dict[str, str]]:
+    """Discover plugin object types from NetBox's object-types API.
+
+    Queries the NetBox instance for installed plugin models that have REST API
+    endpoints and returns them in the same format as NETBOX_OBJECT_TYPES.
+
+    Args:
+        client: Initialized NetBox REST API client
+
+    Returns:
+        Dict mapping type keys (e.g. "netbox_dns.zone") to endpoint info dicts.
+        Returns empty dict on any error (graceful degradation).
+    """
+    logger = logging.getLogger(__name__)
+    plugin_types: dict[str, dict[str, str]] = {}
+
+    try:
+        # Paginate through all object types
+        offset = 0
+        limit = 100
+        while True:
+            response = client.get(
+                "core/object-types",
+                params={"limit": limit, "offset": offset},
+                fallback_endpoint="extras/object-types",  # NetBox < 4.4
+            )
+
+            results = response.get("results", [])
+            for obj_type in results:
+                # Only include plugin models with REST API endpoints
+                if not obj_type.get("is_plugin_model", False):
+                    continue
+
+                rest_url = obj_type.get("rest_api_endpoint")
+                if not rest_url:
+                    continue
+
+                app_label = obj_type.get("app_label", "")
+                model = obj_type.get("model", "")
+                if not app_label or not model:
+                    continue
+
+                type_key = f"{app_label}.{model}"
+
+                # Skip if it would collide with a core type
+                if type_key in NETBOX_OBJECT_TYPES:
+                    logger.debug(f"Skipping plugin type '{type_key}': collides with core type")
+                    continue
+
+                # Convert REST URL to endpoint path:
+                # "/api/plugins/netbox-dns/zones/" -> "plugins/netbox-dns/zones"
+                endpoint = rest_url.strip("/")
+                if endpoint.startswith("api/"):
+                    endpoint = endpoint[4:]
+
+                # Build a display name from the model name
+                display_name = obj_type.get("display", model)
+
+                plugin_types[type_key] = {
+                    "name": display_name,
+                    "endpoint": endpoint,
+                }
+
+            # Check if there are more pages
+            if not response.get("next"):
+                break
+            offset += limit
+
+    except (httpx.HTTPError, ValueError, KeyError) as e:
+        logger.warning(f"Plugin discovery failed, continuing with core types only: {e}")
+        return {}
+
+    if plugin_types:
+        logger.info(
+            f"Discovered {len(plugin_types)} plugin object types: "
+            + ", ".join(sorted(plugin_types.keys()))
+        )
+    else:
+        logger.info("No plugin object types discovered")
+
+    return plugin_types
+
+
+async def _update_tool_descriptions() -> None:
+    """Update tool descriptions to reflect the current NETBOX_OBJECT_TYPES registry.
+
+    The type list in netbox_get_objects's description is built at import time.
+    After plugin discovery adds new types, this refreshes the description so
+    LLMs see the full list of available types.
+    """
+    type_list = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
+    tool = await mcp.get_tool("netbox_get_objects")
+    if tool:
+        # Replace the type list portion of the description
+        desc = tool.description
+        marker = "Valid object_type values:"
+        idx = desc.find(marker)
+        if idx != -1:
+            # Keep everything up to and including the marker, then append new list
+            prefix = desc[: idx + len(marker)]
+            suffix_marker = "See NetBox API documentation"
+            suffix_idx = desc.find(suffix_marker)
+            suffix = (
+                f"\n\n    {suffix_marker}" + desc[suffix_idx + len(suffix_marker) :]
+                if suffix_idx != -1
+                else ""
+            )
+            tool.description = f"{prefix}\n\n{type_list}{suffix}"
+
+
 def main() -> None:
     """Main entry point for the MCP server."""
     global netbox
@@ -569,6 +692,12 @@ def main() -> None:
     except Exception as e:
         logger.error(f"Failed to initialize NetBox client: {e}")
         sys.exit(1)
+
+    if settings.enable_plugin_discovery:
+        plugin_types = discover_plugin_types(netbox)
+        if plugin_types:
+            NETBOX_OBJECT_TYPES.update(plugin_types)
+            asyncio.run(_update_tool_descriptions())
 
     try:
         if settings.transport == "stdio":

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -1,0 +1,262 @@
+"""Tests for plugin object-type discovery.
+
+`discover_plugin_types` queries NetBox's object-types endpoint for installed
+plugin models and returns them in the same format as NETBOX_OBJECT_TYPES.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from netbox_mcp_server.server import discover_plugin_types
+
+
+def _plugin_row(
+    app_label: str,
+    model: str,
+    rest_url: str,
+    display: str | None = None,
+    is_plugin: bool = True,
+) -> dict:
+    row = {
+        "app_label": app_label,
+        "model": model,
+        "rest_api_endpoint": rest_url,
+        "is_plugin_model": is_plugin,
+    }
+    if display is not None:
+        row["display"] = display
+    return row
+
+
+@pytest.fixture
+def client():
+    """Mock NetBox client with a configurable get() method."""
+    return MagicMock()
+
+
+# ============================================================================
+# Happy path
+# ============================================================================
+
+
+def test_discovers_plugin_types(client):
+    """Plugin rows with REST endpoints are returned in expected format."""
+    client.get.return_value = {
+        "results": [
+            _plugin_row(
+                "netbox_dns",
+                "zone",
+                "/api/plugins/netbox-dns/zones/",
+                display="DNS Zone",
+            ),
+        ],
+        "next": None,
+    }
+
+    result = discover_plugin_types(client)
+
+    assert result == {
+        "netbox_dns.zone": {
+            "name": "DNS Zone",
+            "endpoint": "plugins/netbox-dns/zones",
+        },
+    }
+
+
+def test_falls_back_to_model_when_display_missing(client):
+    """If object-type has no `display` field, use the model name."""
+    client.get.return_value = {
+        "results": [
+            _plugin_row("netbox_dns", "zone", "/api/plugins/netbox-dns/zones/"),
+        ],
+        "next": None,
+    }
+
+    result = discover_plugin_types(client)
+
+    assert result["netbox_dns.zone"]["name"] == "zone"
+
+
+# ============================================================================
+# Filtering
+# ============================================================================
+
+
+def test_skips_non_plugin_models(client):
+    """Core (non-plugin) models must be excluded from result."""
+    client.get.return_value = {
+        "results": [
+            _plugin_row("dcim", "device", "/api/dcim/devices/", is_plugin=False),
+            _plugin_row("netbox_dns", "zone", "/api/plugins/netbox-dns/zones/"),
+        ],
+        "next": None,
+    }
+
+    result = discover_plugin_types(client)
+
+    assert "dcim.device" not in result
+    assert "netbox_dns.zone" in result
+
+
+def test_skips_rows_missing_rest_endpoint(client):
+    """Plugin models without a REST API endpoint must be skipped."""
+    client.get.return_value = {
+        "results": [
+            _plugin_row("netbox_dns", "internal_only", rest_url=""),
+            _plugin_row("netbox_dns", "zone", "/api/plugins/netbox-dns/zones/"),
+        ],
+        "next": None,
+    }
+
+    result = discover_plugin_types(client)
+
+    assert "netbox_dns.internal_only" not in result
+    assert "netbox_dns.zone" in result
+
+
+def test_skips_rows_missing_app_label_or_model(client):
+    """Rows missing either app_label or model are ignored."""
+    client.get.return_value = {
+        "results": [
+            {
+                "app_label": "",
+                "model": "zone",
+                "rest_api_endpoint": "/api/plugins/x/zones/",
+                "is_plugin_model": True,
+            },
+            {
+                "app_label": "netbox_dns",
+                "model": "",
+                "rest_api_endpoint": "/api/plugins/x/zones/",
+                "is_plugin_model": True,
+            },
+        ],
+        "next": None,
+    }
+
+    result = discover_plugin_types(client)
+
+    assert result == {}
+
+
+def test_skips_collision_with_core_type(client):
+    """Plugin type whose key collides with a core type is dropped."""
+    client.get.return_value = {
+        "results": [
+            _plugin_row("dcim", "device", "/api/plugins/fake/devices/"),
+        ],
+        "next": None,
+    }
+
+    result = discover_plugin_types(client)
+
+    assert "dcim.device" not in result
+
+
+# ============================================================================
+# REST URL -> endpoint conversion
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    ("rest_url", "expected_endpoint"),
+    [
+        ("/api/plugins/netbox-dns/zones/", "plugins/netbox-dns/zones"),
+        ("api/plugins/netbox-dns/zones/", "plugins/netbox-dns/zones"),
+        ("/plugins/netbox-dns/zones", "plugins/netbox-dns/zones"),
+        (
+            "/api/plugins/netbox-branching/branches/",
+            "plugins/netbox-branching/branches",
+        ),
+    ],
+)
+def test_converts_rest_url_to_endpoint(client, rest_url, expected_endpoint):
+    """REST API URL is normalized by stripping leading /api/ and surrounding slashes."""
+    client.get.return_value = {
+        "results": [_plugin_row("plug", "thing", rest_url)],
+        "next": None,
+    }
+
+    result = discover_plugin_types(client)
+
+    assert result["plug.thing"]["endpoint"] == expected_endpoint
+
+
+# ============================================================================
+# Pagination
+# ============================================================================
+
+
+def test_follows_pagination(client):
+    """Discovery paginates until `next` is null."""
+    page_1 = {
+        "results": [_plugin_row("plug_a", "thing", "/api/plugins/a/things/")],
+        "next": "https://netbox.example.com/api/core/object-types/?limit=100&offset=100",
+    }
+    page_2 = {
+        "results": [_plugin_row("plug_b", "thing", "/api/plugins/b/things/")],
+        "next": None,
+    }
+    client.get.side_effect = [page_1, page_2]
+
+    result = discover_plugin_types(client)
+
+    assert set(result.keys()) == {"plug_a.thing", "plug_b.thing"}
+    assert client.get.call_count == 2
+    # Second call should have advanced the offset
+    second_call_params = client.get.call_args_list[1].kwargs["params"]
+    assert second_call_params["offset"] == 100
+
+
+def test_stops_when_next_missing(client):
+    """Single page with no `next` key terminates cleanly."""
+    client.get.return_value = {
+        "results": [_plugin_row("plug", "thing", "/api/plugins/x/things/")],
+    }
+
+    result = discover_plugin_types(client)
+
+    assert "plug.thing" in result
+    assert client.get.call_count == 1
+
+
+# ============================================================================
+# Graceful degradation
+# ============================================================================
+
+
+def test_returns_empty_dict_on_http_error(client):
+    """HTTP errors are swallowed and empty dict returned."""
+    client.get.side_effect = httpx.HTTPStatusError("500", request=MagicMock(), response=MagicMock())
+
+    result = discover_plugin_types(client)
+
+    assert result == {}
+
+
+def test_returns_empty_dict_on_network_error(client):
+    """Transport errors (timeouts, DNS, connection refused) are swallowed."""
+    client.get.side_effect = httpx.ConnectError("connection refused")
+
+    result = discover_plugin_types(client)
+
+    assert result == {}
+
+
+def test_returns_empty_dict_on_malformed_response(client):
+    """ValueError from unexpected payload shape is swallowed."""
+    client.get.side_effect = ValueError("bad json")
+
+    result = discover_plugin_types(client)
+
+    assert result == {}
+
+
+def test_programmer_errors_still_surface(client):
+    """AttributeError (likely a bug in our code) must not be silently swallowed."""
+    client.get.side_effect = AttributeError("oops")
+
+    with pytest.raises(AttributeError):
+        discover_plugin_types(client)


### PR DESCRIPTION
This MCP is great! 

I had an idea, since our install has plugins installed, to be able to detect those extra objects automatically. LMK what you think