### PR TITLE
feat(tools): add GraphQL query and schema introspection tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ This is a simple read-only [Model Context Protocol](https://modelcontextprotocol
 
 | Tool | Description |
 |------|-------------|
-| get_objects | Retrieves NetBox core objects based on their type and filters |
-| get_object_by_id | Gets detailed information about a specific NetBox object by its ID |
-| get_changelogs | Retrieves change history records (audit trail) based on filters |
+| `get_objects` | Retrieves NetBox core objects based on their type and filters |
+| `get_object_by_id` | Gets detailed information about a specific NetBox object by its ID |
+| `get_changelogs` | Retrieves change history records (audit trail) based on filters |
+| `search_objects` | Searches across multiple object types simultaneously |
+| `graphql_query` | Executes raw GraphQL queries for cross-object data with precise field selection |
+| `graphql_schema_search` | Searches the NetBox GraphQL schema for types and fields by keyword |
+| `graphql_type_details` | Returns detailed field and argument information for a specific GraphQL type |
 
 > Note: the set of supported object types is explicitly defined and limited to the core NetBox objects for now, and won't work with object types from plugins.
 
@@ -150,6 +154,83 @@ devices = netbox_get_objects(
 - **Sites:** `['id', 'name', 'status', 'region', 'description']`
 
 The `fields` parameter uses NetBox's native field filtering. See the [NetBox API documentation](https://docs.netbox.dev/en/stable/integrations/rest-api/) for details.
+
+## GraphQL Tools
+
+The server exposes three GraphQL tools that complement the REST tools, enabling efficient cross-object queries in a single call:
+
+| Tool | Purpose |
+|------|---------|
+| `graphql_query` | Execute raw GraphQL queries against NetBox |
+| `graphql_schema_search` | Discover types and fields by keyword |
+| `graphql_type_details` | Inspect fields and arguments for a specific type |
+
+GraphQL is significantly more efficient than REST for complex queries: a single GraphQL query can retrieve devices, their interfaces, and IP addresses — what would otherwise require 3+ REST tool calls.
+
+**Requirement**: GraphQL must be enabled in your NetBox instance (`GRAPHQL_ENABLED = True`, which is the default). NetBox exposes the GraphQL endpoint at `/graphql/`.
+
+### Discovering the Schema
+
+Use `graphql_schema_search` to discover what types and fields are available before writing a query:
+
+```text
+> Use graphql_schema_search to find types related to "interface"
+> Use graphql_type_details to see all fields on InterfaceType
+> Then use graphql_query to fetch device interfaces and their IPs in one call
+```
+
+### Example Queries
+
+**Devices with interfaces and IP addresses** (replaces 3+ REST calls):
+```graphql
+query {
+  device_list(
+    filters: { status: "active" }
+    pagination: { limit: 10 }
+  ) {
+    id
+    name
+    site { name }
+    interfaces(filters: { enabled: true }) {
+      name
+      ip_addresses { address dns_name }
+    }
+    primary_ip4 { address }
+  }
+}
+```
+
+**IP addresses in a prefix**:
+```graphql
+query {
+  ip_address_list(
+    filters: { parent: "10.0.0.0/24" }
+    pagination: { limit: 50 }
+  ) {
+    address
+    dns_name
+    status
+  }
+}
+```
+
+**Sites with region hierarchy**:
+```graphql
+query {
+  site_list(
+    filters: { status: "active" }
+    pagination: { limit: 20 }
+  ) {
+    name
+    status
+    region { name parent { name } }
+    tenant { name }
+  }
+}
+```
+
+> **Note**: All field names use `snake_case` (e.g., `device_list`, `primary_ip4`, `dns_name`). Always include `pagination` in list queries to avoid large responses.
+
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Use `graphql_schema_search` to discover what types and fields are available befo
 query {
   device_list(
     filters: { status: "active" }
-    pagination: { limit: 10 }
+    pagination: { limit: 10, offset: 0 }
   ) {
     id
     name
@@ -205,7 +205,7 @@ query {
 query {
   ip_address_list(
     filters: { parent: "10.0.0.0/24" }
-    pagination: { limit: 50 }
+    pagination: { limit: 50, offset: 0 }
   ) {
     address
     dns_name
@@ -219,7 +219,7 @@ query {
 query {
   site_list(
     filters: { status: "active" }
-    pagination: { limit: 20 }
+    pagination: { limit: 20, offset: 0 }
   ) {
     name
     status
@@ -229,7 +229,7 @@ query {
 }
 ```
 
-> **Note**: All field names use `snake_case` (e.g., `device_list`, `primary_ip4`, `dns_name`). Always include `pagination` in list queries to avoid large responses.
+> **Note**: All field names use `snake_case` (e.g., `device_list`, `primary_ip4`, `dns_name`). The `pagination` argument requires NetBox 4.3+. On older versions, use `filters` to narrow results.
 
 
 ## Configuration

--- a/src/netbox_mcp_server/graphql_tools.py
+++ b/src/netbox_mcp_server/graphql_tools.py
@@ -40,17 +40,18 @@ def register_graphql_tools(mcp_instance: FastMCP, netbox_client: NetBoxRestClien
         Use netbox_graphql_schema_search to discover available types and fields.
         Use netbox_graphql_type_details to inspect specific type structure.
 
-        CRITICAL: Always include pagination in list queries, e.g.:
-            device_list(pagination: {limit: 50})
-
         All field names use snake_case (e.g., device_list, primary_ip4, site_id).
+
+        On NetBox 4.3+, use pagination to limit list results and avoid large responses:
+            device_list(pagination: {limit: 50, offset: 0})
+        On older NetBox, use filters to narrow results and select only needed fields.
 
         Examples:
             Devices with interfaces and IPs (replaces 3+ REST calls):
                 query {
                   device_list(
                     filters: { status: "active" }
-                    pagination: { limit: 10 }
+                    pagination: { limit: 10, offset: 0 }
                   ) {
                     id
                     name
@@ -67,7 +68,7 @@ def register_graphql_tools(mcp_instance: FastMCP, netbox_client: NetBoxRestClien
                 query {
                   ip_address_list(
                     filters: { parent: "10.0.0.0/24" }
-                    pagination: { limit: 50 }
+                    pagination: { limit: 50, offset: 0 }
                   ) {
                     address
                     dns_name

--- a/src/netbox_mcp_server/graphql_tools.py
+++ b/src/netbox_mcp_server/graphql_tools.py
@@ -46,8 +46,34 @@ def register_graphql_tools(mcp_instance: FastMCP, netbox_client: NetBoxRestClien
         All field names use snake_case (e.g., device_list, primary_ip4, site_id).
 
         Examples:
-            query { device_list(pagination: {limit: 10}) { id name } }
-            query { ip_address_list(pagination: {limit: 50}) { address dns_name } }
+            Devices with interfaces and IPs (replaces 3+ REST calls):
+                query {
+                  device_list(
+                    filters: { status: "active" }
+                    pagination: { limit: 10 }
+                  ) {
+                    id
+                    name
+                    site { name }
+                    interfaces(filters: { enabled: true }) {
+                      name
+                      ip_addresses { address dns_name }
+                    }
+                    primary_ip4 { address }
+                  }
+                }
+
+            IP addresses in a prefix:
+                query {
+                  ip_address_list(
+                    filters: { parent: "10.0.0.0/24" }
+                    pagination: { limit: 50 }
+                  ) {
+                    address
+                    dns_name
+                    status
+                  }
+                }
 
         Args:
             query: GraphQL query string to execute against NetBox
@@ -79,9 +105,9 @@ def register_graphql_tools(mcp_instance: FastMCP, netbox_client: NetBoxRestClien
         are available. Search by concept name to find relevant types.
 
         Examples:
-            netbox_graphql_schema_search("device") -> finds DeviceType, device_list, etc.
-            netbox_graphql_schema_search("interface") -> finds InterfaceType and related fields
-            netbox_graphql_schema_search("ip") -> finds IPAddressType, ip_address_list, etc.
+            netbox_graphql_schema_search("device") -> returns matching types and fields
+            netbox_graphql_schema_search("interface") -> returns interface-related types and fields
+            netbox_graphql_schema_search("ip") -> returns IP-related types and fields
 
         Args:
             keyword: Case-insensitive keyword to search for in type names and field names

--- a/src/netbox_mcp_server/graphql_tools.py
+++ b/src/netbox_mcp_server/graphql_tools.py
@@ -1,0 +1,263 @@
+"""
+NetBox GraphQL MCP Tools
+
+Provides MCP tools for querying the NetBox GraphQL API.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import requests
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+    from netbox_mcp_server.netbox_client import NetBoxRestClient
+
+logger = logging.getLogger(__name__)
+
+
+def register_graphql_tools(mcp_instance: FastMCP, netbox_client: NetBoxRestClient) -> None:
+    """Register GraphQL tools on the MCP server.
+
+    Args:
+        mcp_instance: The FastMCP server instance to register tools on
+        netbox_client: The NetBox REST client for making GraphQL requests
+    """
+
+    @mcp_instance.tool
+    def netbox_graphql_query(
+        query: str,
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Execute a GraphQL query against the NetBox GraphQL API.
+
+        Use this tool to fetch cross-object data in a single query with precise field
+        selection — far more efficient than multiple REST API calls.
+
+        Use netbox_graphql_schema_search to discover available types and fields.
+        Use netbox_graphql_type_details to inspect specific type structure.
+
+        CRITICAL: Always include pagination in list queries, e.g.:
+            device_list(pagination: {limit: 50})
+
+        All field names use snake_case (e.g., device_list, primary_ip4, site_id).
+
+        Examples:
+            query { device_list(pagination: {limit: 10}) { id name } }
+            query { ip_address_list(pagination: {limit: 50}) { address dns_name } }
+
+        Args:
+            query: GraphQL query string to execute against NetBox
+            variables: Optional dict of query variables for parameterized queries
+
+        Returns:
+            GraphQL response dict with 'data' and/or 'errors' keys, or an 'error'
+            key if the response is too large or GraphQL is unavailable.
+        """
+        if not query or not query.strip():
+            raise ValueError("query must be a non-empty GraphQL query string")
+
+        try:
+            return netbox_client.graphql(query, variables)
+        except ValueError as e:
+            return {"error": str(e)}
+        except requests.HTTPError as e:
+            return {"error": f"HTTP error querying NetBox GraphQL: {e}"}
+
+    @mcp_instance.tool
+    def netbox_graphql_schema_search(
+        keyword: str,
+        max_types: int = 10,
+        include_internal_types: bool = False,
+    ) -> dict[str, Any]:
+        """Search the NetBox GraphQL schema for types and fields matching a keyword.
+
+        Use this tool BEFORE writing a GraphQL query to discover what types and fields
+        are available. Search by concept name to find relevant types.
+
+        Examples:
+            netbox_graphql_schema_search("device") -> finds DeviceType, device_list, etc.
+            netbox_graphql_schema_search("interface") -> finds InterfaceType and related fields
+            netbox_graphql_schema_search("ip") -> finds IPAddressType, ip_address_list, etc.
+
+        Args:
+            keyword: Case-insensitive keyword to search for in type names and field names
+            max_types: Maximum number of matching types to return (default 10, max 50)
+            include_internal_types: Include GraphQL internal types (prefixed with '__')
+
+        Returns:
+            Dict with 'keyword', 'matching_types' (list of type info dicts),
+            'matching_fields' (list of field matches with their parent type),
+            and 'total_matches' count. Returns 'error' key if introspection fails.
+        """
+        if not keyword or not keyword.strip():
+            raise ValueError("keyword must be a non-empty search string")
+
+        max_types = max(1, min(50, max_types))
+        keyword_lower = keyword.lower()
+
+        introspection_query = """
+        {
+          __schema {
+            types {
+              name
+              kind
+              description
+              fields {
+                name
+                description
+              }
+            }
+          }
+        }
+        """
+
+        try:
+            result = netbox_client.graphql(introspection_query)
+        except (ValueError, requests.HTTPError) as e:
+            return {"error": f"GraphQL introspection failed: {e}"}
+
+        if "error" in result:
+            return result
+
+        types = result.get("data", {}).get("__schema", {}).get("types", [])
+
+        matching_types: list[dict[str, Any]] = []
+        matching_fields: list[dict[str, Any]] = []
+
+        for type_info in types:
+            type_name = type_info.get("name", "")
+
+            if not include_internal_types and type_name.startswith("__"):
+                continue
+
+            type_matches = keyword_lower in type_name.lower()
+            if type_matches and len(matching_types) < max_types:
+                matching_types.append(
+                    {
+                        "name": type_name,
+                        "kind": type_info.get("kind"),
+                        "description": type_info.get("description"),
+                    }
+                )
+
+            for field in type_info.get("fields") or []:
+                field_name = field.get("name", "")
+                field_desc = field.get("description", "") or ""
+                if keyword_lower in field_name.lower() or keyword_lower in field_desc.lower():
+                    matching_fields.append(
+                        {
+                            "field_name": field_name,
+                            "parent_type": type_name,
+                            "description": field.get("description"),
+                        }
+                    )
+
+        if not matching_types and not matching_fields:
+            return {
+                "keyword": keyword,
+                "matching_types": [],
+                "matching_fields": [],
+                "total_matches": 0,
+                "message": (
+                    f"No types or fields matching '{keyword}'. Try broader terms like "
+                    "'device', 'ip', 'vlan', 'site'."
+                ),
+            }
+
+        return {
+            "keyword": keyword,
+            "matching_types": matching_types,
+            "matching_fields": matching_fields[:50],
+            "total_matches": len(matching_types) + len(matching_fields),
+        }
+
+    @mcp_instance.tool
+    def netbox_graphql_type_details(type_name: str) -> dict[str, Any]:
+        """Get detailed field and argument information for a specific NetBox GraphQL type.
+
+        Use this tool after netbox_graphql_schema_search to inspect the exact fields,
+        arguments, and nested types available for a specific GraphQL type before
+        writing your query.
+
+        Examples:
+            netbox_graphql_type_details("DeviceType") -> fields: id, name, site, interfaces, ...
+            netbox_graphql_type_details("InterfaceType") -> fields: name, ip_addresses, ...
+            netbox_graphql_type_details("IPAddressType") -> fields: address, dns_name, status, ...
+
+        Args:
+            type_name: The exact GraphQL type name to introspect (case-sensitive)
+
+        Returns:
+            Dict with type details including 'name', 'kind', 'description', 'fields'
+            (each with name, type, description, and args), and 'enum_values' for
+            enum types. Returns 'error' key if type not found or introspection fails.
+        """
+        if not type_name or not type_name.strip():
+            raise ValueError("type_name must be a non-empty string")
+
+        escaped_type_name = type_name.replace('"', '\\"')
+        introspection_query = """
+        {
+          __type(name: "__TYPE_NAME__") {
+            name
+            kind
+            description
+            fields {
+              name
+              description
+              type {
+                name
+                kind
+                ofType {
+                  name
+                  kind
+                }
+              }
+              args {
+                name
+                description
+                type {
+                  name
+                  kind
+                }
+              }
+            }
+            enumValues {
+              name
+              description
+            }
+            inputFields {
+              name
+              description
+              type {
+                name
+                kind
+              }
+            }
+          }
+        }
+        """
+        introspection_query = introspection_query.replace("__TYPE_NAME__", escaped_type_name)
+
+        try:
+            result = netbox_client.graphql(introspection_query)
+        except (ValueError, requests.HTTPError) as e:
+            return {"error": f"GraphQL introspection failed: {e}"}
+
+        if "error" in result:
+            return result
+
+        type_data = result.get("data", {}).get("__type")
+        if type_data is None:
+            return {
+                "error": (
+                    f"Type '{type_name}' not found in NetBox GraphQL schema. "
+                    "Use netbox_graphql_schema_search to discover available types."
+                )
+            }
+
+        return type_data

--- a/src/netbox_mcp_server/netbox_client.py
+++ b/src/netbox_mcp_server/netbox_client.py
@@ -345,3 +345,46 @@ class NetBoxRestClient(NetBoxClientBase):
         response = self.session.delete(url, json=data, verify=self.verify_ssl)
         response.raise_for_status()
         return response.status_code == 204
+
+    def graphql(self, query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+        """
+        Execute a GraphQL query against the NetBox GraphQL API.
+
+        Args:
+            query: The GraphQL query string to execute
+            variables: Optional dictionary of query variables
+
+        Returns:
+            The GraphQL response as a dict with 'data' and/or 'errors' keys.
+            If the response exceeds 500KB, returns a dict with an 'error' key
+            describing the issue and guidance to narrow the query.
+
+        Raises:
+            requests.HTTPError: If the HTTP request fails (4xx/5xx)
+            ValueError: If the response is not JSON (GraphQL may be disabled or unavailable)
+        """
+        url = f"{self.base_url}/graphql/"
+        payload: dict[str, Any] = {"query": query}
+        if variables:
+            payload["variables"] = variables
+
+        response = self.session.post(url, json=payload, verify=self.verify_ssl)
+        response.raise_for_status()
+
+        content_type = response.headers.get("Content-Type", "")
+        if "application/json" not in content_type:
+            raise ValueError(
+                f"NetBox returned non-JSON response (Content-Type: {content_type}). "
+                "GraphQL may be disabled (GRAPHQL_ENABLED=False) or unavailable."
+            )
+
+        max_size = 500 * 1024
+        if len(response.content) > max_size:
+            return {
+                "error": (
+                    f"Response too large ({len(response.content):,} bytes, limit 500KB). "
+                    "Narrow your query by selecting fewer fields or adding filters/pagination."
+                )
+            }
+
+        return response.json()

--- a/src/netbox_mcp_server/netbox_client.py
+++ b/src/netbox_mcp_server/netbox_client.py
@@ -383,7 +383,7 @@ class NetBoxRestClient(NetBoxClientBase):
             return {
                 "error": (
                     f"Response too large ({len(response.content):,} bytes, limit 500KB). "
-                    "Narrow your query by selecting fewer fields or adding filters/pagination."
+                    "Narrow your query by selecting fewer fields or adding more specific filters."
                 )
             }
 

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -7,6 +7,7 @@ from fastmcp import FastMCP
 from pydantic import Field
 
 from netbox_mcp_server.config import Settings, configure_logging
+from netbox_mcp_server.graphql_tools import register_graphql_tools
 from netbox_mcp_server.netbox_client import NetBoxRestClient
 from netbox_mcp_server.netbox_types import NETBOX_OBJECT_TYPES
 
@@ -569,6 +570,8 @@ def main() -> None:
     except Exception as e:
         logger.error(f"Failed to initialize NetBox client: {e}")
         sys.exit(1)
+
+    register_graphql_tools(mcp, netbox)
 
     try:
         if settings.transport == "stdio":

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -576,6 +576,8 @@ def test_schema_search_then_type_details_workflow(mock_netbox_client: MagicMock)
     mock_netbox_client.graphql.return_value = {
         "data": {"device_list": [{"id": 1, "name": "router-01"}]}
     }
-    query_result = query_tool(query="{ device_list(pagination: {limit: 10}) { id name } }")
+    query_result = query_tool(
+        query="{ device_list(filters: { status: STATUS_ACTIVE }) { id name } }"
+    )
     assert "data" in query_result
     assert query_result["data"]["device_list"][0]["name"] == "router-01"

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -4,11 +4,14 @@ The GraphQL method provides access to NetBox's GraphQL API endpoint,
 which is located at /graphql/ (not under /api/).
 """
 
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 
+from netbox_mcp_server.graphql_tools import register_graphql_tools
 from netbox_mcp_server.netbox_client import NetBoxRestClient
 
 
@@ -134,3 +137,369 @@ def test_graphql_oversized_response_returns_truncation_message(client):
         assert "error" in result
         assert "500KB" in result["error"] or "500" in result["error"]
         assert "narrow" in result["error"].lower() or "query" in result["error"].lower()
+
+
+# --- GraphQL Query Tool Tests ---
+
+
+class _ToolCapture:
+    """Capture tool functions registered via @mcp.tool."""
+
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable[..., dict[str, Any]]] = {}
+
+    def tool(self, func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
+        self.tools[func.__name__] = func
+        return func
+
+
+@pytest.fixture
+def mock_netbox_client() -> MagicMock:
+    """Return a mocked NetBox client for tool testing."""
+    return MagicMock(spec=NetBoxRestClient)
+
+
+def _make_graphql_query_tool(
+    mock_client: MagicMock,
+) -> Callable[..., dict[str, Any]]:
+    """Register graphql tools and return netbox_graphql_query."""
+    capture = _ToolCapture()
+    register_graphql_tools(capture, mock_client)
+    return capture.tools["netbox_graphql_query"]
+
+
+def test_graphql_query_valid(mock_netbox_client: MagicMock):
+    """netbox_graphql_query should return raw client GraphQL data."""
+    mock_netbox_client.graphql.return_value = {"data": {"device_list": [{"id": 1}]}}
+
+    tool = _make_graphql_query_tool(mock_netbox_client)
+    result = tool(query="{ device_list { id } }")
+
+    assert result == {"data": {"device_list": [{"id": 1}]}}
+    mock_netbox_client.graphql.assert_called_once_with("{ device_list { id } }", None)
+
+
+def test_graphql_query_with_variables(mock_netbox_client: MagicMock):
+    """netbox_graphql_query should pass variables to client.graphql."""
+    mock_netbox_client.graphql.return_value = {"data": {"device": {"id": 1, "name": "router-01"}}}
+
+    tool = _make_graphql_query_tool(mock_netbox_client)
+    result = tool(
+        query="query GetDevice($id: Int!) { device(id: $id) { id name } }",
+        variables={"id": 1},
+    )
+
+    assert result == {"data": {"device": {"id": 1, "name": "router-01"}}}
+    mock_netbox_client.graphql.assert_called_once_with(
+        "query GetDevice($id: Int!) { device(id: $id) { id name } }",
+        {"id": 1},
+    )
+
+
+def test_graphql_query_partial_errors_returned_intact(mock_netbox_client: MagicMock):
+    """netbox_graphql_query should return partial data and errors unchanged."""
+    graphql_response = {
+        "data": {"device_list": [{"id": 1}]},
+        "errors": [{"message": "Field 'foo' not found"}],
+    }
+    mock_netbox_client.graphql.return_value = graphql_response
+
+    tool = _make_graphql_query_tool(mock_netbox_client)
+    result = tool(query="{ device_list { id foo } }")
+
+    assert result == graphql_response
+
+
+def test_graphql_query_http_error_returns_error_dict(mock_netbox_client: MagicMock):
+    """netbox_graphql_query should return error dict on HTTPError."""
+    mock_netbox_client.graphql.side_effect = requests.HTTPError("503 Service Unavailable")
+
+    tool = _make_graphql_query_tool(mock_netbox_client)
+    result = tool(query="{ device_list { id } }")
+
+    assert result == {"error": "HTTP error querying NetBox GraphQL: 503 Service Unavailable"}
+
+
+def test_graphql_query_value_error_returns_error_dict(mock_netbox_client: MagicMock):
+    """netbox_graphql_query should return error dict on ValueError."""
+    mock_netbox_client.graphql.side_effect = ValueError("GraphQL disabled")
+
+    tool = _make_graphql_query_tool(mock_netbox_client)
+    result = tool(query="{ device_list { id } }")
+
+    assert result == {"error": "GraphQL disabled"}
+
+
+def test_graphql_query_empty_query_raises_value_error(mock_netbox_client: MagicMock):
+    """netbox_graphql_query should validate non-empty query."""
+    tool = _make_graphql_query_tool(mock_netbox_client)
+
+    with pytest.raises(ValueError, match="non-empty GraphQL query string"):
+        tool(query="")
+
+
+def test_graphql_query_whitespace_query_raises_value_error(mock_netbox_client: MagicMock):
+    """netbox_graphql_query should reject whitespace-only query strings."""
+    tool = _make_graphql_query_tool(mock_netbox_client)
+
+    with pytest.raises(ValueError, match="non-empty GraphQL query string"):
+        tool(query="   \n\t")
+
+
+def _make_schema_search_tool(mock_client: MagicMock) -> Callable[..., dict[str, Any]]:
+    capture = _ToolCapture()
+    register_graphql_tools(capture, mock_client)
+    return capture.tools["netbox_graphql_schema_search"]
+
+
+def test_schema_search_matches_type_names(mock_netbox_client: MagicMock):
+    mock_netbox_client.graphql.return_value = {
+        "data": {
+            "__schema": {
+                "types": [
+                    {
+                        "name": "DeviceType",
+                        "kind": "OBJECT",
+                        "description": "A network device",
+                        "fields": [],
+                    }
+                ]
+            }
+        }
+    }
+
+    tool = _make_schema_search_tool(mock_netbox_client)
+    result = tool(keyword="device")
+
+    assert any(t["name"] == "DeviceType" for t in result["matching_types"])
+
+
+def test_schema_search_matches_field_names(mock_netbox_client: MagicMock):
+    mock_netbox_client.graphql.return_value = {
+        "data": {
+            "__schema": {
+                "types": [
+                    {
+                        "name": "IPAddressType",
+                        "kind": "OBJECT",
+                        "description": "IP address",
+                        "fields": [
+                            {"name": "ip_address", "description": "Address"},
+                            {"name": "dns_name", "description": "DNS"},
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+
+    tool = _make_schema_search_tool(mock_netbox_client)
+    result = tool(keyword="ip")
+
+    assert any(f["field_name"] == "ip_address" for f in result["matching_fields"])
+
+
+def test_schema_search_excludes_internal_types_by_default(mock_netbox_client: MagicMock):
+    mock_netbox_client.graphql.return_value = {
+        "data": {
+            "__schema": {
+                "types": [
+                    {
+                        "name": "__Schema",
+                        "kind": "OBJECT",
+                        "description": "Internal schema type",
+                        "fields": [],
+                    }
+                ]
+            }
+        }
+    }
+
+    tool = _make_schema_search_tool(mock_netbox_client)
+    result = tool(keyword="schema")
+
+    type_names = {t["name"] for t in result["matching_types"]}
+    assert "__Schema" not in type_names
+
+
+def test_schema_search_includes_internal_types_when_requested(
+    mock_netbox_client: MagicMock,
+):
+    mock_netbox_client.graphql.return_value = {
+        "data": {
+            "__schema": {
+                "types": [
+                    {
+                        "name": "__Schema",
+                        "kind": "OBJECT",
+                        "description": "Internal schema type",
+                        "fields": [],
+                    }
+                ]
+            }
+        }
+    }
+
+    tool = _make_schema_search_tool(mock_netbox_client)
+    result = tool(keyword="schema", include_internal_types=True)
+
+    type_names = {t["name"] for t in result["matching_types"]}
+    assert "__Schema" in type_names
+
+
+def test_schema_search_no_matches_returns_message(mock_netbox_client: MagicMock):
+    mock_netbox_client.graphql.return_value = {
+        "data": {
+            "__schema": {
+                "types": [
+                    {
+                        "name": "DeviceType",
+                        "kind": "OBJECT",
+                        "description": "A network device",
+                        "fields": [{"name": "name", "description": "Device name"}],
+                    }
+                ]
+            }
+        }
+    }
+
+    tool = _make_schema_search_tool(mock_netbox_client)
+    result = tool(keyword="xyznonexistent")
+
+    assert result["matching_types"] == []
+    assert result["matching_fields"] == []
+    assert "message" in result
+
+
+def test_schema_search_introspection_failure_returns_error(
+    mock_netbox_client: MagicMock,
+):
+    mock_netbox_client.graphql.side_effect = requests.HTTPError("503 Service Unavailable")
+
+    tool = _make_schema_search_tool(mock_netbox_client)
+    result = tool(keyword="device")
+
+    assert "error" in result
+    assert "introspection failed" in result["error"]
+
+
+def test_schema_search_empty_keyword_raises(mock_netbox_client: MagicMock):
+    tool = _make_schema_search_tool(mock_netbox_client)
+
+    with pytest.raises(ValueError, match="non-empty search string"):
+        tool(keyword="")
+
+
+def test_schema_search_max_types_limits_results(mock_netbox_client: MagicMock):
+    many_types = [
+        {
+            "name": f"DeviceType{i}",
+            "kind": "OBJECT",
+            "description": "Device-like type",
+            "fields": [],
+        }
+        for i in range(20)
+    ]
+    mock_netbox_client.graphql.return_value = {"data": {"__schema": {"types": many_types}}}
+
+    tool = _make_schema_search_tool(mock_netbox_client)
+    result = tool(keyword="device", max_types=3)
+
+    assert len(result["matching_types"]) <= 3
+
+
+def _make_type_details_tool(mock_client: MagicMock) -> Callable[..., dict[str, Any]]:
+    capture = _ToolCapture()
+    register_graphql_tools(capture, mock_client)
+    return capture.tools["netbox_graphql_type_details"]
+
+
+def test_type_details_valid_type_returns_fields(mock_netbox_client: MagicMock):
+    mock_netbox_client.graphql.return_value = {
+        "data": {
+            "__type": {
+                "name": "DeviceType",
+                "kind": "OBJECT",
+                "fields": [{"name": "id"}],
+                "enumValues": None,
+                "inputFields": None,
+            }
+        }
+    }
+
+    tool = _make_type_details_tool(mock_netbox_client)
+    result = tool(type_name="DeviceType")
+
+    assert result["name"] == "DeviceType"
+    assert isinstance(result["fields"], list)
+
+
+def test_type_details_type_not_found_returns_error(mock_netbox_client: MagicMock):
+    mock_netbox_client.graphql.return_value = {"data": {"__type": None}}
+
+    tool = _make_type_details_tool(mock_netbox_client)
+    result = tool(type_name="NonExistentType")
+
+    assert "error" in result
+    assert "NonExistentType" in result["error"]
+
+
+def test_type_details_introspection_failure_returns_error(mock_netbox_client: MagicMock):
+    mock_netbox_client.graphql.side_effect = requests.HTTPError("503")
+
+    tool = _make_type_details_tool(mock_netbox_client)
+    result = tool(type_name="DeviceType")
+
+    assert "error" in result
+    assert "introspection failed" in result["error"]
+
+
+def test_type_details_empty_type_name_raises(mock_netbox_client: MagicMock):
+    tool = _make_type_details_tool(mock_netbox_client)
+
+    with pytest.raises(ValueError, match="non-empty string"):
+        tool(type_name="")
+
+
+def test_type_details_enum_type_returns_enum_values(mock_netbox_client: MagicMock):
+    mock_netbox_client.graphql.return_value = {
+        "data": {
+            "__type": {
+                "name": "StatusEnum",
+                "kind": "ENUM",
+                "enumValues": [{"name": "active", "description": "Active"}],
+                "fields": None,
+                "inputFields": None,
+            }
+        }
+    }
+
+    tool = _make_type_details_tool(mock_netbox_client)
+    result = tool(type_name="StatusEnum")
+
+    assert result["kind"] == "ENUM"
+    assert result["enumValues"][0]["name"] == "active"
+
+
+def test_type_details_query_string_has_quoted_type_name(mock_netbox_client: MagicMock):
+    """The introspection query must quote the type name (valid GraphQL syntax)."""
+    mock_netbox_client.graphql.return_value = {
+        "data": {
+            "__type": {
+                "name": "DeviceType",
+                "kind": "OBJECT",
+                "description": None,
+                "fields": [],
+                "enumValues": None,
+                "inputFields": None,
+            }
+        }
+    }
+    tool = _make_type_details_tool(mock_netbox_client)
+    tool(type_name="DeviceType")
+
+    call_args = mock_netbox_client.graphql.call_args
+    query_sent = call_args[0][0]
+    assert '"DeviceType"' in query_sent, (
+        f"Type name must be quoted in query. Got: {query_sent[:200]}"
+    )

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -503,3 +503,79 @@ def test_type_details_query_string_has_quoted_type_name(mock_netbox_client: Magi
     assert '"DeviceType"' in query_sent, (
         f"Type name must be quoted in query. Got: {query_sent[:200]}"
     )
+
+
+# --- Integration Tests ---
+
+
+def test_all_three_tools_are_registered():
+    """All 3 GraphQL tools should be registered when register_graphql_tools is called."""
+    capture = _ToolCapture()
+    mock_client = MagicMock(spec=NetBoxRestClient)
+    register_graphql_tools(capture, mock_client)
+
+    assert "netbox_graphql_query" in capture.tools
+    assert "netbox_graphql_schema_search" in capture.tools
+    assert "netbox_graphql_type_details" in capture.tools
+
+
+def test_schema_search_then_type_details_workflow(mock_netbox_client: MagicMock):
+    """Verify the discovery workflow: search schema -> get type details -> execute query."""
+    capture = _ToolCapture()
+    register_graphql_tools(capture, mock_netbox_client)
+
+    schema_search = capture.tools["netbox_graphql_schema_search"]
+    type_details = capture.tools["netbox_graphql_type_details"]
+    query_tool = capture.tools["netbox_graphql_query"]
+
+    # Step 1: Search for "device" types
+    mock_netbox_client.graphql.return_value = {
+        "data": {
+            "__schema": {
+                "types": [
+                    {
+                        "name": "DeviceType",
+                        "kind": "OBJECT",
+                        "description": "A network device",
+                        "fields": [
+                            {"name": "id", "description": "ID"},
+                            {"name": "name", "description": "Name"},
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    search_result = schema_search(keyword="device")
+    assert "matching_types" in search_result
+
+    # Step 2: Get details for DeviceType
+    mock_netbox_client.graphql.return_value = {
+        "data": {
+            "__type": {
+                "name": "DeviceType",
+                "kind": "OBJECT",
+                "description": "A network device",
+                "fields": [
+                    {
+                        "name": "id",
+                        "description": "ID",
+                        "type": {"name": "Int", "kind": "SCALAR", "ofType": None},
+                        "args": [],
+                    }
+                ],
+                "enumValues": None,
+                "inputFields": None,
+            }
+        }
+    }
+    details_result = type_details(type_name="DeviceType")
+    assert details_result.get("name") == "DeviceType"
+
+    # Step 3: Execute a query using what we learned
+    mock_netbox_client.graphql.return_value = {
+        "data": {"device_list": [{"id": 1, "name": "router-01"}]}
+    }
+    query_result = query_tool(query="{ device_list(pagination: {limit: 10}) { id name } }")
+    assert "data" in query_result
+    assert query_result["data"]["device_list"][0]["name"] == "router-01"

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,0 +1,136 @@
+"""Tests for NetBoxRestClient GraphQL method.
+
+The GraphQL method provides access to NetBox's GraphQL API endpoint,
+which is located at /graphql/ (not under /api/).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from netbox_mcp_server.netbox_client import NetBoxRestClient
+
+
+@pytest.fixture
+def client():
+    """Create a test client."""
+    return NetBoxRestClient(
+        url="https://netbox.example.com",
+        token="test-token",
+        verify_ssl=True,
+    )
+
+
+def test_graphql_valid_query(client):
+    """GraphQL method should return parsed JSON response for valid query."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.content = b'{"data": {"device_list": [{"id": 1}]}}'
+    mock_response.json.return_value = {"data": {"device_list": [{"id": 1}]}}
+    mock_response.raise_for_status.return_value = None
+
+    with patch.object(client.session, "post") as mock_post:
+        mock_post.return_value = mock_response
+
+        result = client.graphql("{ device_list { id } }")
+
+        assert result == {"data": {"device_list": [{"id": 1}]}}
+        mock_post.assert_called_once()
+
+
+def test_graphql_with_variables(client):
+    """GraphQL method should include variables in POST body."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.content = b'{"data": {"device": {"id": 1, "name": "router-01"}}}'
+    mock_response.json.return_value = {"data": {"device": {"id": 1, "name": "router-01"}}}
+    mock_response.raise_for_status.return_value = None
+
+    with patch.object(client.session, "post") as mock_post:
+        mock_post.return_value = mock_response
+
+        result = client.graphql(
+            "query GetDevice($id: Int!) { device(id: $id) { id name } }",
+            variables={"id": 1},
+        )
+
+        # Verify POST body contains query and variables
+        call_args = mock_post.call_args
+        assert (
+            call_args[1]["json"]["query"]
+            == "query GetDevice($id: Int!) { device(id: $id) { id name } }"
+        )
+        assert call_args[1]["json"]["variables"] == {"id": 1}
+        assert result == {"data": {"device": {"id": 1, "name": "router-01"}}}
+
+
+def test_graphql_url_uses_base_url_not_api_url(client):
+    """GraphQL URL should use /graphql/ not /api/graphql/."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.content = b'{"data": {}}'
+    mock_response.json.return_value = {"data": {}}
+    mock_response.raise_for_status.return_value = None
+
+    with patch.object(client.session, "post") as mock_post:
+        mock_post.return_value = mock_response
+
+        client.graphql("{ test }")
+
+        # Verify URL is correct
+        call_args = mock_post.call_args
+        url = call_args[0][0]
+        assert url == "https://netbox.example.com/graphql/"
+        assert "/api/graphql/" not in url
+
+
+def test_graphql_http_error_raises(client):
+    """GraphQL method should raise HTTPError on 4xx/5xx responses."""
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+    mock_response.raise_for_status.side_effect = requests.HTTPError("401 Unauthorized")
+
+    with patch.object(client.session, "post") as mock_post:
+        mock_post.return_value = mock_response
+
+        with pytest.raises(requests.HTTPError, match="401 Unauthorized"):
+            client.graphql("{ test }")
+
+
+def test_graphql_non_json_response_raises_value_error(client):
+    """GraphQL method should raise ValueError for non-JSON responses."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "text/html"}
+    mock_response.content = b"<html>GraphQL is disabled</html>"
+    mock_response.raise_for_status.return_value = None
+
+    with patch.object(client.session, "post") as mock_post:
+        mock_post.return_value = mock_response
+
+        with pytest.raises(ValueError, match=r"non-JSON|GraphQL may be disabled"):
+            client.graphql("{ test }")
+
+
+def test_graphql_oversized_response_returns_truncation_message(client):
+    """GraphQL method should return error dict for responses exceeding 500KB."""
+    oversized_content = b"x" * 600_000  # 600KB
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.content = oversized_content
+    mock_response.raise_for_status.return_value = None
+
+    with patch.object(client.session, "post") as mock_post:
+        mock_post.return_value = mock_response
+
+        result = client.graphql("{ test }")
+
+        assert "error" in result
+        assert "500KB" in result["error"] or "500" in result["error"]
+        assert "narrow" in result["error"].lower() or "query" in result["error"].lower()


### PR DESCRIPTION
Complex queries against NetBox currently require multiple sequential tool calls — fetching
a device, then its interfaces, then their IP addresses means 3+ round-trips, each
returning fully-expanded nested objects that consume significant context. NetBox's GraphQL
API (`/graphql/`) exposes the same data with precise field selection and cross-object
joins in a single request, but it's been inaccessible from the MCP server.

This adds three tools built around a new `graphql()` method on `NetBoxRestClient`:
`netbox_graphql_query` executes raw GraphQL queries, while `netbox_graphql_schema_search`
and `netbox_graphql_type_details` give LLMs a way to discover the schema before writing
queries — the same discovery-then-query pattern used by Cloudflare's GraphQL MCP server.