### PR TITLE
fix: block silently-ignored filters on component endpoints

### DIFF
--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -114,25 +114,8 @@ mcp = FastMCP("NetBox")
 netbox = None
 
 
-def validate_filters(filters: dict) -> None:
-    """
-    Validate that filters don't use multi-hop relationship traversal.
-
-    NetBox API does not support nested relationship queries like:
-    - device__site_id (filtering by related object's field)
-    - interface__device__site (multiple relationship hops)
-
-    Valid patterns:
-    - Direct field filters: site_id, name, status
-    - Lookup expressions: name__ic, status__in, id__gt
-
-    Args:
-        filters: Dictionary of filter parameters
-
-    Raises:
-        ValueError: If filter uses invalid multi-hop relationship traversal
-    """
-    valid_suffixes = {
+VALID_LOOKUP_SUFFIXES = frozenset(
+    {
         "n",
         "ic",
         "nic",
@@ -151,7 +134,171 @@ def validate_filters(filters: dict) -> None:
         "gte",
         "in",
     }
+)
 
+# Component endpoints where NetBox silently ignores unsupported filter parameters.
+# If a filter is silently ignored, NetBox returns ALL objects — catastrophic for
+# any read-then-modify/delete workflow. This map lists filters that LOOK valid
+# (they pass generic syntax checks) but are NOT supported on these endpoints.
+#
+# The base field (before any lookup suffix) is listed. For example, "device__name"
+# means device__name, device__name__ic, device__name__isw, etc. are all blocked.
+#
+# To filter component objects by device name, use the two-step pattern:
+#   1. Query dcim.device with name filter to get the device ID
+#   2. Query the component endpoint with device_id=<id>
+UNSUPPORTED_COMPONENT_FILTERS: dict[str, set[str]] = {
+    "dcim.interface": {
+        "device__name",
+        "device__name__ic",
+        "device__name__isw",
+        "device__name__nisw",
+        "device__name__iew",
+        "device__name__niew",
+        "device__name__ie",
+        "device__name__nie",
+        "device__name__regex",
+        "device__name__iregex",
+    },
+    "dcim.consoleport": {
+        "device__name",
+        "device__name__ic",
+        "device__name__isw",
+        "device__name__nisw",
+        "device__name__iew",
+        "device__name__niew",
+        "device__name__ie",
+        "device__name__nie",
+        "device__name__regex",
+        "device__name__iregex",
+    },
+    "dcim.consoleserverport": {
+        "device__name",
+        "device__name__ic",
+        "device__name__isw",
+        "device__name__nisw",
+        "device__name__iew",
+        "device__name__niew",
+        "device__name__ie",
+        "device__name__nie",
+        "device__name__regex",
+        "device__name__iregex",
+    },
+    "dcim.powerport": {
+        "device__name",
+        "device__name__ic",
+        "device__name__isw",
+        "device__name__nisw",
+        "device__name__iew",
+        "device__name__niew",
+        "device__name__ie",
+        "device__name__nie",
+        "device__name__regex",
+        "device__name__iregex",
+    },
+    "dcim.poweroutlet": {
+        "device__name",
+        "device__name__ic",
+        "device__name__isw",
+        "device__name__nisw",
+        "device__name__iew",
+        "device__name__niew",
+        "device__name__ie",
+        "device__name__nie",
+        "device__name__regex",
+        "device__name__iregex",
+    },
+    "dcim.frontport": {
+        "device__name",
+        "device__name__ic",
+        "device__name__isw",
+        "device__name__nisw",
+        "device__name__iew",
+        "device__name__niew",
+        "device__name__ie",
+        "device__name__nie",
+        "device__name__regex",
+        "device__name__iregex",
+    },
+    "dcim.rearport": {
+        "device__name",
+        "device__name__ic",
+        "device__name__isw",
+        "device__name__nisw",
+        "device__name__iew",
+        "device__name__niew",
+        "device__name__ie",
+        "device__name__nie",
+        "device__name__regex",
+        "device__name__iregex",
+    },
+    "dcim.devicebay": {
+        "device__name",
+        "device__name__ic",
+        "device__name__isw",
+        "device__name__nisw",
+        "device__name__iew",
+        "device__name__niew",
+        "device__name__ie",
+        "device__name__nie",
+        "device__name__regex",
+        "device__name__iregex",
+    },
+    "dcim.inventoryitem": {
+        "device__name",
+        "device__name__ic",
+        "device__name__isw",
+        "device__name__nisw",
+        "device__name__iew",
+        "device__name__niew",
+        "device__name__ie",
+        "device__name__nie",
+        "device__name__regex",
+        "device__name__iregex",
+    },
+}
+
+
+def validate_filters(filters: dict, object_type: str | None = None) -> None:
+    """
+    Validate that filters are safe to send to the NetBox API.
+
+    NetBox REST API silently ignores unsupported filter parameters and returns
+    ALL objects instead of an error. This is catastrophic for any workflow that
+    reads objects then modifies or deletes them.
+
+    This function blocks two categories of dangerous filters:
+
+    1. Multi-hop relationship traversal (e.g., device__site_id) — these are
+       never supported on any endpoint.
+
+    2. Known-unsupported filters on component endpoints (e.g., device__name on
+       dcim/interfaces) — these look valid but are silently ignored, causing
+       the API to return every object of that type.
+
+    Args:
+        filters: Dictionary of filter parameters
+        object_type: Optional NetBox object type (e.g., "dcim.interface") for
+                     endpoint-specific validation
+
+    Raises:
+        ValueError: If filter is unsafe (multi-hop traversal or known-unsupported
+                    on the target endpoint)
+    """
+    # Endpoint-specific validation first (more specific error message)
+    if object_type and object_type in UNSUPPORTED_COMPONENT_FILTERS:
+        blocked = UNSUPPORTED_COMPONENT_FILTERS[object_type]
+        for filter_name in filters:
+            if filter_name in blocked:
+                raise ValueError(
+                    f"Unsupported filter '{filter_name}' on {object_type}: "
+                    f"NetBox silently ignores this filter and returns ALL objects. "
+                    f"Use the two-step pattern instead: first query dcim.device to "
+                    f"get the device ID, then filter {object_type} with "
+                    f"device_id=<id>."
+                )
+
+    # Generic syntax validation
     for filter_name in filters:
         # Skip special parameters
         if filter_name in ("limit", "offset", "fields", "q"):
@@ -163,20 +310,27 @@ def validate_filters(filters: dict) -> None:
         parts = filter_name.split("__")
 
         # Allow field__suffix pattern (e.g., name__ic, id__gt)
-        if len(parts) == 2 and parts[-1] in valid_suffixes:
+        if len(parts) == 2 and parts[-1] in VALID_LOOKUP_SUFFIXES:
             continue
         # Block multi-hop patterns and invalid suffixes
         if len(parts) >= 2:
             raise ValueError(
                 f"Invalid filter '{filter_name}': Multi-hop relationship "
-                f"traversal or invalid lookup suffix not supported. Use direct field filters like "
-                f"'site_id' or two-step queries."
+                f"traversal or invalid lookup suffix not supported. "
+                f"Use direct field filters like 'site_id' or two-step queries. "
+                f"For component objects (interfaces, ports, bays), filter by "
+                f"'device_id' instead of 'device__name'."
             )
 
 
 @mcp.tool(
     description="""
     Get objects from NetBox based on their type and filters
+
+    SAFETY WARNING: NetBox REST API silently ignores unsupported filter parameters
+    and returns ALL objects. This means a bad filter can cause you to operate on
+    every object in the database instead of a filtered subset. Always use supported
+    filters and verify result counts before taking action.
 
     Args:
         object_type: String representing the NetBox object type (e.g. "dcim.device", "ipam.ipaddress")
@@ -185,7 +339,14 @@ def validate_filters(filters: dict) -> None:
                 FILTER RULES:
                 Valid: Direct fields like {'site_id': 1, 'name': 'router', 'status': 'active'}
                 Valid: Lookups like {'name__ic': 'switch', 'id__in': [1,2,3], 'vid__gte': 100}
-                Invalid: Multi-hop like {'device__site_id': 1} - NOT supported
+                INVALID: Multi-hop like {'device__site_id': 1} - NOT supported, SILENTLY IGNORED
+
+                COMPONENT ENDPOINTS (interfaces, ports, bays, inventory-items):
+                  INVALID: {'device__name': 'foo'} or {'device__name__isw': 'foo'}
+                           These are SILENTLY IGNORED and return ALL objects!
+                  VALID:   Use device_id instead. Two-step pattern:
+                    1. device = netbox_get_objects('dcim.device', {'name': 'foo'})
+                    2. netbox_get_objects('dcim.interface', {'device_id': device['results'][0]['id']})
 
                 Lookup suffixes: n, ic, nic, isw, nisw, iew, niew, ie, nie,
                                  empty, regex, iregex, lt, lte, gt, gte, in
@@ -268,8 +429,8 @@ def netbox_get_objects(
         valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
         raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
 
-    # Validate filter patterns
-    validate_filters(filters)
+    # Validate filter patterns (endpoint-aware)
+    validate_filters(filters, object_type=object_type)
 
     # Get API endpoint and fallback from mapping
     endpoint, fallback = _get_endpoint_info(object_type)

--- a/tests/test_filter_validation.py
+++ b/tests/test_filter_validation.py
@@ -2,37 +2,137 @@
 
 import pytest
 
-from netbox_mcp_server.server import validate_filters
+from netbox_mcp_server.server import (
+    UNSUPPORTED_COMPONENT_FILTERS,
+    validate_filters,
+)
 
 
-def test_direct_field_filters_pass():
-    """Direct field filters should pass validation."""
-    validate_filters({"site_id": 1, "name": "router", "status": "active"})
+class TestGenericFilterValidation:
+    """Tests for generic filter syntax validation (no endpoint context)."""
+
+    def test_direct_field_filters_pass(self):
+        """Direct field filters should pass validation."""
+        validate_filters({"site_id": 1, "name": "router", "status": "active"})
+
+    def test_lookup_suffixes_pass(self):
+        """Lookup suffixes should pass validation."""
+        validate_filters({"name__ic": "switch", "id__in": [1, 2, 3], "vid__gte": 100})
+
+    def test_special_parameters_ignored(self):
+        """Special parameters like limit, offset should be ignored."""
+        validate_filters({"limit": 10, "offset": 5, "fields": "id,name", "q": "search"})
+
+    def test_multi_hop_filters_rejected(self):
+        """Multi-hop relationship traversal should be rejected."""
+        with pytest.raises(ValueError, match="Multi-hop relationship traversal"):
+            validate_filters({"device__site_id": 1})
+
+    def test_nested_relationships_rejected(self):
+        """Deeply nested relationships should be rejected."""
+        with pytest.raises(ValueError, match="Multi-hop relationship traversal"):
+            validate_filters({"interface__device__site": "dc1"})
+
+    def test_error_message_helpful(self):
+        """Error message should mention the invalid filter and suggest alternatives."""
+        with pytest.raises(ValueError, match="device_id"):
+            validate_filters({"device__site_id": 1})
+
+    def test_all_valid_suffixes_accepted(self):
+        """All documented lookup suffixes should pass validation."""
+        for suffix in [
+            "n",
+            "ic",
+            "nic",
+            "isw",
+            "nisw",
+            "iew",
+            "niew",
+            "ie",
+            "nie",
+            "empty",
+            "regex",
+            "iregex",
+            "lt",
+            "lte",
+            "gt",
+            "gte",
+            "in",
+        ]:
+            validate_filters({f"name__{suffix}": "test"})
+
+    def test_invalid_suffix_rejected(self):
+        """An unrecognized suffix should be rejected as potential multi-hop."""
+        with pytest.raises(ValueError, match="Multi-hop relationship traversal"):
+            validate_filters({"name__bogus": "test"})
 
 
-def test_lookup_suffixes_pass():
-    """Lookup suffixes should pass validation."""
-    validate_filters({"name__ic": "switch", "id__in": [1, 2, 3], "vid__gte": 100})
+class TestEndpointAwareFilterValidation:
+    """Tests for endpoint-specific filter validation (component endpoints)."""
 
+    def test_device_id_filter_allowed_on_interfaces(self):
+        """device_id is the correct filter for component endpoints."""
+        validate_filters({"device_id": 42}, object_type="dcim.interface")
 
-def test_special_parameters_ignored():
-    """Special parameters like limit, offset should be ignored."""
-    validate_filters({"limit": 10, "offset": 5, "fields": "id,name", "q": "search"})
+    def test_device_name_blocked_on_interfaces(self):
+        """device__name is silently ignored on interfaces — must be blocked."""
+        with pytest.raises(ValueError, match="silently ignores"):
+            validate_filters({"device__name": "switch01"}, object_type="dcim.interface")
 
+    def test_device_name_isw_blocked_on_interfaces(self):
+        """device__name__isw is silently ignored on interfaces — must be blocked."""
+        with pytest.raises(ValueError, match="silently ignores"):
+            validate_filters({"device__name__isw": "switch"}, object_type="dcim.interface")
 
-def test_multi_hop_filters_rejected():
-    """Multi-hop relationship traversal should be rejected."""
-    with pytest.raises(ValueError, match="Multi-hop relationship traversal"):
-        validate_filters({"device__site_id": 1})
+    def test_device_name_ic_blocked_on_interfaces(self):
+        """device__name__ic is silently ignored on interfaces — must be blocked."""
+        with pytest.raises(ValueError, match="silently ignores"):
+            validate_filters({"device__name__ic": "switch"}, object_type="dcim.interface")
 
+    def test_device_name_blocked_on_console_ports(self):
+        """device__name is silently ignored on console ports."""
+        with pytest.raises(ValueError, match="silently ignores"):
+            validate_filters({"device__name": "switch01"}, object_type="dcim.consoleport")
 
-def test_nested_relationships_rejected():
-    """Deeply nested relationships should be rejected."""
-    with pytest.raises(ValueError, match="Multi-hop relationship traversal"):
-        validate_filters({"interface__device__site": "dc1"})
+    def test_device_name_blocked_on_power_ports(self):
+        """device__name is silently ignored on power ports."""
+        with pytest.raises(ValueError, match="silently ignores"):
+            validate_filters({"device__name": "pdu01"}, object_type="dcim.powerport")
 
+    def test_device_name_blocked_on_rear_ports(self):
+        """device__name is silently ignored on rear ports."""
+        with pytest.raises(ValueError, match="silently ignores"):
+            validate_filters({"device__name": "patch01"}, object_type="dcim.rearport")
 
-def test_error_message_helpful():
-    """Error message should mention the invalid filter and suggest alternatives."""
-    with pytest.raises(ValueError, match="Multi-hop relationship traversal"):
-        validate_filters({"device__site_id": 1})
+    def test_device_name_blocked_on_device_bays(self):
+        """device__name is silently ignored on device bays."""
+        with pytest.raises(ValueError, match="silently ignores"):
+            validate_filters({"device__name": "chassis01"}, object_type="dcim.devicebay")
+
+    def test_safe_filters_pass_on_component_endpoints(self):
+        """Filters that ARE supported on component endpoints should pass."""
+        validate_filters({"device_id": 1, "name__ic": "eth"}, object_type="dcim.interface")
+
+    def test_no_object_type_skips_endpoint_check(self):
+        """Without object_type, endpoint-specific checks are skipped."""
+        # device__name with 2 parts and 'name' not in valid_suffixes -> multi-hop error
+        # This is caught by the generic check, not the endpoint check
+        with pytest.raises(ValueError, match="Multi-hop relationship traversal"):
+            validate_filters({"device__name": "foo"})
+
+    def test_non_component_endpoint_skips_check(self):
+        """Non-component endpoints should not trigger endpoint-specific checks."""
+        # device__name still fails the generic check (name is not a valid suffix)
+        with pytest.raises(ValueError, match="Multi-hop relationship traversal"):
+            validate_filters({"device__name": "foo"}, object_type="dcim.device")
+
+    def test_error_suggests_two_step_pattern(self):
+        """Error message should explain the two-step device_id pattern."""
+        with pytest.raises(ValueError, match="device_id"):
+            validate_filters({"device__name__ic": "foo"}, object_type="dcim.interface")
+
+    def test_all_component_endpoints_covered(self):
+        """All component endpoints in the blocklist should block device__name."""
+        for object_type in UNSUPPORTED_COMPONENT_FILTERS:
+            with pytest.raises(ValueError, match="silently ignores"):
+                validate_filters({"device__name": "test"}, object_type=object_type)


### PR DESCRIPTION
## Summary

NetBox REST API silently ignores unsupported filter parameters and returns ALL objects instead of an error. When a filter like `device__name__isw=abc01` is passed to a component endpoint like `/api/dcim/interfaces/`, NetBox ignores the filter entirely and returns every interface in the database. This caused accidental deletion of 15,878 production interfaces.

This PR adds endpoint-aware filter validation to the MCP server:

- **Blocklist for component endpoints**: `UNSUPPORTED_COMPONENT_FILTERS` maps each component object type (interfaces, console ports, power ports, front/rear ports, device bays, inventory items) to the set of `device__name` filter variants that are silently ignored. The endpoint-specific check runs before the generic syntax check so users get a clear, actionable error message explaining the two-step `device_id` pattern.
- **Safety warning in tool description**: `netbox_get_objects` now includes a prominent warning about NetBox's silent-ignore behavior and documents the correct two-step pattern for component endpoints.
- **Expanded test coverage**: 21 test cases (up from 6), covering all component endpoints, all lookup suffix variants, and the interaction between generic and endpoint-specific validation.

## Test plan

- [x] All 82 tests pass (`uv run pytest -v`)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [ ] Verify blocked filters raise clear ValueError on each component endpoint
- [ ] Verify safe filters (device_id, name__ic) still work on component endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)