### PR TITLE
fix: exclude requires-python from Renovate bumps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,6 +10,12 @@
   rangeStrategy: 'bump',
 
   packageRules: [
+    // Don't bump requires-python — it defines minimum supported version, not installed version
+    {
+      matchDepNames: ['python'],
+      enabled: false,
+    },
+
     // Python
     {
       description: 'Group non-major Python dependency updates',


### PR DESCRIPTION
## Summary

- Disable Renovate updates for the `python` (`requires-python`) field
- `rangeStrategy: 'bump'` was changing `>=3.11,<3.15` → `>=3.14.3,<3.15`, breaking CI on Python 3.11/3.12
- `requires-python` defines minimum supported version — it should only be changed manually when dropping Python version support

Fixes the test failures in #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)