### PR TITLE
fix: scope requires-python exclusion to pep621 manager only

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,7 @@
     // Don't bump requires-python — it defines minimum supported version, not installed version
     {
       matchDepNames: ['python'],
+      matchManagers: ['pep621'],
       enabled: false,
     },
 


### PR DESCRIPTION
## Summary

- Add `matchManagers: ['pep621']` to the Python exclusion rule
- Without this, `matchDepNames: ['python']` also disables updates for the `python` Docker base image (`FROM python:3.14-alpine3.23`)
- Dockerfile dependencies were showing as empty on the Dependency Dashboard because of this

🤖 Generated with [Claude Code](https://claude.com/claude-code)