### PR TITLE
Pin GitHub Actions digests in Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -28,8 +28,9 @@
 
     // GitHub Actions
     {
-      description: 'Group non-major GitHub Actions updates',
+      description: 'GitHub Actions - SHA-pin and group non-major updates',
       matchManagers: ['github-actions'],
+      pinDigests: true,
       matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
       groupName: 'non-major GitHub Actions',
       minimumReleaseAge: '3 days',


### PR DESCRIPTION
Enable `pinDigests: true` for GitHub Actions so Renovate SHA-pins action references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)