### PR TITLE
fix(ci): add CHANGELOG insertion flag for python-semantic-release v10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+<!-- version list -->
+
 ## v1.0.0 (2025-10-31)
 
 ### 🚨 BREAKING CHANGES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ allowed_tags = ["feat", "fix", "docs", "chore", "refactor", "test", "ci", "perf"
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
 
-[tool.semantic_release.changelog]
+[tool.semantic_release.changelog.default_templates]
 changelog_file = "CHANGELOG.md"
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

The first run of the PR-based release workflow opened [#115](https://github.com/netboxlabs/netbox-mcp-server/pull/115) with `pyproject.toml` and `__init__.py` bumped, but without a `CHANGELOG.md` entry. Closed that PR; this fixes the root cause.

## Root cause

`python-semantic-release` v10's default changelog `mode = "update"` inserts new release sections at a `<!-- version list -->` marker in the target file. Our `CHANGELOG.md` predates this convention, so the writer silently no-ops when the workflow generates a new version.

## Changes

- **`CHANGELOG.md`** — add the `<!-- version list -->` marker between the title and the first version heading. Existing v1.0.0 / v0.1.0 content is untouched; new release sections are inserted at the marker.
- **`pyproject.toml`** — rename `[tool.semantic_release.changelog]` to `[tool.semantic_release.changelog.default_templates]` to silence the v10 deprecation warning. Same option, new section name.

No workflow changes required.

## Validation

Reproduced locally against `python-semantic-release==10.5.3` by applying these changes and running the same command the workflow uses:

```bash
uvx --from 'python-semantic-release==10.5.3' semantic-release version \
  --no-commit --no-push --no-tag --no-vcs-release --skip-build
```

Result: CHANGELOG.md, pyproject.toml, and __init__.py are all updated; the v1.1.0 section groups the unreleased commits under Features / Bug Fixes as expected.

## Test plan

- [ ] CI passes
- [ ] After merge, re-dispatch the **Release PR** workflow
- [ ] Verify the new release PR includes the `## v1.1.0` section in CHANGELOG.md
- [ ] Merging that PR creates the `v1.1.0` tag and GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)