### PR TITLE
fix(ci): extract full release notes from CHANGELOG

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -49,7 +49,7 @@ jobs:
               content = f.read()
 
           pattern = re.compile(
-              rf"^#+\s*v?{re.escape(version)}\b[^\n]*\n(.*?)(?=\n#+\s|\Z)",
+              rf"^## v?{re.escape(version)}\b[^\n]*\n(.*?)(?=\n## |\Z)",
               re.MULTILINE | re.DOTALL,
           )
           match = pattern.search(content)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           uvx --from 'python-semantic-release==10.5.3' semantic-release version \
             --no-commit --no-push --no-tag --no-vcs-release --skip-build
+          uv lock
           NEW_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           printf 'new_version=%s\n' "${NEW_VERSION}" >> "${GITHUB_OUTPUT}"
 
@@ -62,6 +63,7 @@ jobs:
             pyproject.toml
             src/netbox_mcp_server/__init__.py
             CHANGELOG.md
+            uv.lock
           labels: |
             release
             automated

--- a/uv.lock
+++ b/uv.lock
@@ -1017,7 +1017,7 @@ wheels = [
 
 [[package]]
 name = "netbox-mcp-server"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Two fixes for the release workflow pipeline:

1. **Release notes extraction** — the regex stopped at the first `###` subsection heading instead of the next `##` version heading, producing an empty body on the v1.1.0 GitHub Release. Narrows the lookahead to match only version headings.

2. **Lockfile sync** — `semantic-release` bumps the version in `pyproject.toml` but the release PR didn't regenerate `uv.lock`, breaking the Docker build on merge. Adds `uv lock` after the version bump and includes `uv.lock` in the PR paths.

v1.1.0 release notes have been backfilled separately.

## Test plan

- [ ] CI passes
- [ ] Next release PR includes an updated `uv.lock` and Docker build passes
- [ ] Next release produces a GitHub Release with populated notes