### PR TITLE
fix(server): restore strict JSON Schema types; add --n8n-compat opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The server supports multiple configuration sources with the following precedence
 | `PORT` | Integer | `8000` | If HTTP | Port for HTTP server |
 | `VERIFY_SSL` | Boolean | `true` | No | Whether to verify SSL certificates |
 | `LOG_LEVEL` | `DEBUG` \| `INFO` \| `WARNING` \| `ERROR` \| `CRITICAL` | `INFO` | No | Logging verbosity |
+| `NETBOX_MCP_N8N_COMPAT` | Boolean | `false` | No | Enable n8n AI Agent MCP client compatibility mode (string-typed parameters). See [n8n Compatibility Mode](#n8n-compatibility-mode). |
 
 ### Transport Examples
 
@@ -250,6 +251,37 @@ uv run netbox-mcp-server --help
 uv run netbox-mcp-server --log-level DEBUG --no-verify-ssl  # Development
 uv run netbox-mcp-server --transport http --port 9000       # Custom HTTP port
 ```
+
+### n8n Compatibility Mode
+
+The n8n AI Agent MCP client does not currently support JSON Schema
+`integer`, `array`, or `object` parameter types — it has a hardcoded
+type-mapping table covering only `string`, `number`, `boolean`, and
+`json`. If you're connecting this server from n8n, enable compatibility
+mode:
+
+```bash
+# Via environment variable
+NETBOX_MCP_N8N_COMPAT=true uv run netbox-mcp-server
+
+# Or via CLI flag
+uv run netbox-mcp-server --n8n-compat
+```
+
+In compat mode:
+
+- `filters` is a JSON string (e.g. `'{"site_id": 1}'`) instead of an object
+- `fields`, `ordering`, and `object_types` are comma-separated strings instead of arrays
+- `limit`, `offset`, and `object_id` are `number` instead of `integer`
+
+**Upstream tracking:** A [community PR][n8n-pr] proposes the fix but has
+been unreviewed since October 2025. This flag will be removed once that
+fix (or equivalent) ships in an n8n release. See the relevant upstream
+reports: [n8n#19835][n8n-19835], [n8n#21569][n8n-21569].
+
+[n8n-pr]: https://github.com/n8n-io/n8n/pull/20682
+[n8n-19835]: https://github.com/n8n-io/n8n/issues/19835
+[n8n-21569]: https://github.com/n8n-io/n8n/issues/21569
 
 ## Docker Usage
 

--- a/src/netbox_mcp_server/config.py
+++ b/src/netbox_mcp_server/config.py
@@ -4,7 +4,7 @@ import logging
 import logging.config
 from typing import Any, Literal
 
-from pydantic import AnyUrl, SecretStr, field_validator, model_validator
+from pydantic import AnyUrl, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -42,6 +42,18 @@ class Settings(BaseSettings):
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
     """Logging verbosity level"""
 
+    # ===== n8n Compatibility =====
+    n8n_compat: bool = Field(
+        default=False,
+        validation_alias="NETBOX_MCP_N8N_COMPAT",
+        description=(
+            "Enable n8n AI Agent MCP client compatibility. Exposes tool "
+            "parameters as strings instead of native JSON Schema types "
+            "(integer/array/object). Required when connecting from n8n. "
+            "See n8n-io/n8n#20682."
+        ),
+    )
+
     # ===== Pydantic Configuration =====
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -71,6 +83,24 @@ class Settings(BaseSettings):
             )
         return v
 
+    @model_validator(mode="before")
+    @classmethod
+    def _map_n8n_compat_field_name(cls, values: Any) -> Any:
+        """Allow direct construction with n8n_compat= kwarg despite validation_alias.
+
+        pydantic-settings resolves env vars via the alias, but direct Python
+        callers (tests, library users) may pass n8n_compat= by field name.
+        This validator remaps the field name to the alias before validation
+        so both styles work without exposing N8N_COMPAT as an accepted env var.
+        """
+        if (
+            isinstance(values, dict)
+            and "n8n_compat" in values
+            and "NETBOX_MCP_N8N_COMPAT" not in values
+        ):
+            values["NETBOX_MCP_N8N_COMPAT"] = values.pop("n8n_compat")
+        return values
+
     @model_validator(mode="after")
     def validate_http_transport_requirements(self) -> "Settings":
         """No additional validation needed for HTTP transport; defaults are appropriate."""
@@ -91,6 +121,7 @@ class Settings(BaseSettings):
             "port": self.port if self.transport == "http" else "N/A",
             "verify_ssl": self.verify_ssl,
             "log_level": self.log_level,
+            "n8n_compat": self.n8n_compat,
         }
 
 

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -292,7 +292,7 @@ _NETBOX_GET_OBJECTS_DESCRIPTION = (
 
                 Two-step pattern for cross-relationship queries:
                   sites = netbox_get_objects('dcim.site', {"name": "NYC"})
-                  netbox_get_objects('dcim.device', {"site_id": 1})
+                  netbox_get_objects('dcim.device', {"site_id": sites[0]['id']})
 
         fields: List of specific fields to return
                 **IMPORTANT: ALWAYS USE THIS PARAMETER TO MINIMIZE TOKEN USAGE**
@@ -310,23 +310,39 @@ _NETBOX_GET_OBJECTS_DESCRIPTION = (
                 **Always specify only the fields you actually need.**
 
         brief: returns only a minimal representation of each object in the response.
+               This is useful when you need only a list of available objects without any related data.
 
         limit: Maximum results to return (default 5, max 100)
+               Start with default, increase only if needed
 
         offset: Skip this many results for pagination (default 0)
+                Example: offset=0 (page 1), offset=5 (page 2), offset=10 (page 3)
 
         ordering: Fields used to determine sort order of results.
                   Field names may be prefixed with '-' to invert the sort order.
-                  Use comma-separated string for multiple fields.
+                  Multiple fields may be specified with a list of strings or a
+                  comma-separated string.
 
                   Examples:
                   - 'name' (alphabetical by name)
                   - '-id' (ordered by ID descending)
-                  - 'facility,-name' (by facility, then by name descending)
+                  - ['facility', '-name'] (by facility, then by name descending)
+                  - 'facility,-name' (same as above, comma-separated form)
+                  - None, '' or [] (default NetBox ordering)
 
 
     Returns:
-        Paginated response dict with count / next / previous / results.
+        Paginated response dict with the following structure:
+            - count: Total number of objects matching the query
+                     ALWAYS REFER TO THIS FIELD FOR THE TOTAL NUMBER OF OBJECTS MATCHING THE QUERY
+            - next: URL to next page (or null if no more pages)
+                    ALWAYS REFER TO THIS FIELD FOR THE NEXT PAGE OF RESULTS
+            - previous: URL to previous page (or null if on first page)
+                        ALWAYS REFER TO THIS FIELD FOR THE PREVIOUS PAGE OF RESULTS
+            - results: Array of objects for this page
+                       ALWAYS REFER TO THIS FIELD FOR THE OBJECTS ON THIS PAGE
+
+    ENSURE YOU ARE AWARE THE RESULTS ARE PAGINATED BEFORE PROVIDING RESPONSE TO THE USER.
 
     Valid object_type values:
 
@@ -346,9 +362,10 @@ def netbox_get_objects(
     brief: bool = False,
     limit: Annotated[int, Field(ge=1, le=100)] = 5,
     offset: Annotated[int, Field(ge=0)] = 0,
-    ordering: str = "",
+    ordering: str | list[str] | None = None,
 ) -> Any:
     """Strict-mode wrapper (default). Takes native Python types."""
+    ordering_str = ",".join(ordering) if isinstance(ordering, list) else ordering or ""
     return _netbox_get_objects_impl(
         object_type=object_type,
         filters=filters or {},
@@ -356,7 +373,7 @@ def netbox_get_objects(
         brief=brief,
         limit=limit,
         offset=offset,
-        ordering=ordering,
+        ordering=ordering_str,
     )
 
 
@@ -422,17 +439,64 @@ def _netbox_get_changelogs_impl(filters: dict[str, Any]) -> Any:
     return netbox.get("core/object-changes", params=filters)
 
 
-def netbox_get_changelogs(filters: dict[str, Any] | None = None) -> Any:
-    """Strict-mode wrapper for netbox_get_changelogs.
-
+_NETBOX_GET_CHANGELOGS_DESCRIPTION = """
     Get object change records (changelogs) from NetBox based on filters.
 
     Args:
-        filters: Dict of filters to apply to the API call.
+        filters: dict of filters to apply to the API call based on the NetBox API filtering options
 
     Returns:
-        Paginated response dict.
+        Paginated response dict with the following structure:
+            - count: Total number of changelog entries matching the query
+                     ALWAYS REFER TO THIS FIELD FOR THE TOTAL NUMBER OF CHANGELOG ENTRIES MATCHING THE QUERY
+            - next: URL to next page (or null if no more pages)
+                    ALWAYS REFER TO THIS FIELD FOR THE NEXT PAGE OF RESULTS
+            - previous: URL to previous page (or null if on first page)
+                        ALWAYS REFER TO THIS FIELD FOR THE PREVIOUS PAGE OF RESULTS
+            - results: Array of changelog entries for this page
+                       ALWAYS REFER TO THIS FIELD FOR THE CHANGELOG ENTRIES ON THIS PAGE
+
+    Filtering options include:
+    - user_id: Filter by user ID who made the change
+    - user: Filter by username who made the change
+    - changed_object_type_id: Filter by numeric ContentType ID (e.g., 21 for dcim.device)
+                              Note: This expects a numeric ID, not an object type string
+    - changed_object_id: Filter by ID of the changed object
+    - object_repr: Filter by object representation (usually contains object name)
+    - action: Filter by action type (created, updated, deleted)
+    - time_before: Filter for changes made before a given time (ISO 8601 format)
+    - time_after: Filter for changes made after a given time (ISO 8601 format)
+    - q: Search term to filter by object representation
+
+    Examples:
+    To find all changes made to a specific object by ID:
+    {"changed_object_id": 123}
+
+    To find changes by object name pattern:
+    {"object_repr": "router-01"}
+
+    To find all deletions in the last 24 hours:
+    {"action": "delete", "time_after": "2023-01-01T00:00:00Z"}
+
+    Each changelog entry contains:
+    - id: The unique identifier of the changelog entry
+    - user: The user who made the change
+    - user_name: The username of the user who made the change
+    - request_id: The unique identifier of the request that made the change
+    - action: The type of action performed (created, updated, deleted)
+    - changed_object_type: The type of object that was changed
+    - changed_object_id: The ID of the object that was changed
+    - object_repr: String representation of the changed object
+    - object_data: The object's data after the change (null for deletions)
+    - object_data_v2: Enhanced data representation
+    - prechange_data: The object's data before the change (null for creations)
+    - postchange_data: The object's data after the change (null for deletions)
+    - time: The timestamp when the change was made
     """
+
+
+def netbox_get_changelogs(filters: dict[str, Any] | None = None) -> Any:
+    """Strict-mode wrapper for netbox_get_changelogs. See tool description."""
     return _netbox_get_changelogs_impl(filters or {})
 
 
@@ -533,7 +597,7 @@ def _register_strict_tools(mcp: FastMCP) -> None:
     """Register strict-typed tools (native int/list/dict). Default mode."""
     mcp.tool(description=_NETBOX_GET_OBJECTS_DESCRIPTION)(netbox_get_objects)
     mcp.tool()(netbox_get_object_by_id)
-    mcp.tool()(netbox_get_changelogs)
+    mcp.tool(description=_NETBOX_GET_CHANGELOGS_DESCRIPTION)(netbox_get_changelogs)
     mcp.tool(description=_NETBOX_SEARCH_OBJECTS_DESCRIPTION)(netbox_search_objects)
 
 
@@ -581,7 +645,7 @@ def _register_compat_tools(mcp: FastMCP) -> None:
             brief=brief,
         )
 
-    @mcp.tool()
+    @mcp.tool(description=_NETBOX_GET_CHANGELOGS_DESCRIPTION)
     def netbox_get_changelogs(filters: str = "{}") -> Any:
         """n8n-compat wrapper for netbox_get_changelogs."""
         return _netbox_get_changelogs_impl(_parse_filters(filters))

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -78,6 +78,16 @@ def parse_cli_args() -> dict[str, Any]:
         help="Logging verbosity level (default: INFO)",
     )
 
+    # n8n compatibility
+    parser.add_argument(
+        "--n8n-compat",
+        action="store_true",
+        dest="n8n_compat",
+        default=None,
+        help="Enable n8n AI Agent MCP client compatibility mode "
+        "(string-typed tool parameters). See README.",
+    )
+
     args: argparse.Namespace = parser.parse_args()
 
     overlay: dict[str, Any] = {}
@@ -95,6 +105,8 @@ def parse_cli_args() -> dict[str, Any]:
         overlay["verify_ssl"] = args.verify_ssl
     if args.log_level is not None:
         overlay["log_level"] = args.log_level
+    if args.n8n_compat is not None:
+        overlay["n8n_compat"] = args.n8n_compat
 
     return overlay
 

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -554,7 +554,7 @@ def _register_compat_tools(mcp: FastMCP) -> None:
         limit: Annotated[float, Field(default=5.0, ge=1.0, le=100.0)] = 5.0,
         offset: Annotated[float, Field(default=0.0, ge=0.0)] = 0.0,
         ordering: str = "",
-    ):
+    ) -> Any:
         """n8n-compat wrapper. Parses strings to native types, calls impl."""
         return _netbox_get_objects_impl(
             object_type=object_type,
@@ -572,7 +572,7 @@ def _register_compat_tools(mcp: FastMCP) -> None:
         object_id: float,
         fields: str = "",
         brief: bool = False,
-    ):
+    ) -> Any:
         """n8n-compat wrapper for netbox_get_object_by_id."""
         return _netbox_get_object_by_id_impl(
             object_type=object_type,
@@ -582,7 +582,7 @@ def _register_compat_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool()
-    def netbox_get_changelogs(filters: str = "{}"):
+    def netbox_get_changelogs(filters: str = "{}") -> Any:
         """n8n-compat wrapper for netbox_get_changelogs."""
         return _netbox_get_changelogs_impl(_parse_filters(filters))
 

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -123,7 +123,6 @@ DEFAULT_SEARCH_TYPES = [
     "virtualization.virtualmachine",  # VM names
 ]
 
-mcp = FastMCP("NetBox")
 netbox = None
 
 # Some MCP clients (e.g., n8n) send literal strings for empty optional parameters
@@ -137,12 +136,14 @@ def _is_empty_string(value: str) -> bool:
 
 
 def _parse_filters(filters: str | dict[str, Any] | None) -> dict[str, Any]:
-    """Parse filters parameter from JSON string or dict.
+    """Parse filters parameter from JSON string or dict (n8n-compat mode only).
 
-    MCP clients always send a JSON string (tool schema advertises `string`).
-    The dict branch is a convenience for direct Python callers (tests,
-    library usage); it is unreachable via the MCP boundary because Pydantic
-    rejects non-string inputs before the function runs.
+    Called from the compat-mode tool wrappers, which advertise ``filters`` as
+    a JSON string via the MCP schema. Accepts a dict too as a convenience for
+    direct Python callers, but MCP clients in compat mode always send strings.
+
+    Strict-mode (default) wrappers take native dicts and do not call this
+    helper.
     """
     if filters is None:
         return {}
@@ -157,12 +158,14 @@ def _parse_filters(filters: str | dict[str, Any] | None) -> dict[str, Any]:
 
 
 def _parse_list_param(value: str | list[str] | None) -> list[str]:
-    """Parse list parameter from comma-separated string or list.
+    """Parse a list parameter from a comma-separated string or list (n8n-compat mode only).
 
-    MCP clients always send a comma-separated string (tool schema advertises
-    `string`). The list branch is a convenience for direct Python callers; it
-    is unreachable via the MCP boundary because Pydantic rejects non-string
-    inputs before the function runs.
+    Called from the compat-mode tool wrappers, which advertise list-like
+    parameters as comma-separated strings via the MCP schema. Accepts a list
+    as a convenience for direct Python callers.
+
+    Strict-mode (default) wrappers take native ``list[str]`` and do not call
+    this helper.
     """
     if value is None:
         return []
@@ -271,49 +274,46 @@ def _netbox_get_objects_impl(
     return netbox.get(endpoint, params=params, fallback_endpoint=fallback)
 
 
-@mcp.tool(
-    description="""
+_NETBOX_GET_OBJECTS_DESCRIPTION = (
+    """
     Get objects from NetBox based on their type and filters
 
     Args:
         object_type: String representing the NetBox object type (e.g. "dcim.device", "ipam.ipaddress")
-        filters: JSON string of filters to apply to the API call based on the NetBox API filtering options
+        filters: Filters to apply to the API call based on the NetBox API filtering options
 
                 FILTER RULES:
-                Valid: Direct fields like '{"site_id": 1, "name": "router", "status": "active"}'
-                Valid: Lookups like '{"name__ic": "switch", "id__in": [1,2,3], "vid__gte": 100}'
-                Invalid: Multi-hop like '{"device__site_id": 1}' - NOT supported
+                Valid: Direct fields like {"site_id": 1, "name": "router", "status": "active"}
+                Valid: Lookups like {"name__ic": "switch", "id__in": [1,2,3], "vid__gte": 100}
+                Invalid: Multi-hop like {"device__site_id": 1} - NOT supported
 
                 Lookup suffixes: n, ic, nic, isw, nisw, iew, niew, ie, nie,
                                  empty, regex, iregex, lt, lte, gt, gte, in
 
                 Two-step pattern for cross-relationship queries:
-                  sites = netbox_get_objects('dcim.site', '{"name": "NYC"}')
-                  netbox_get_objects('dcim.device', '{"site_id": 1}')
+                  sites = netbox_get_objects('dcim.site', {"name": "NYC"})
+                  netbox_get_objects('dcim.device', {"site_id": 1})
 
-        fields: Comma-separated string of specific fields to return
+        fields: List of specific fields to return
                 **IMPORTANT: ALWAYS USE THIS PARAMETER TO MINIMIZE TOKEN USAGE**
                 Field filtering significantly reduces response payload and is critical for performance.
 
-                - Empty string '' = returns all fields (NOT RECOMMENDED - use only when you need complete objects)
-                - 'id,name' = returns only specified fields (RECOMMENDED)
+                - None or [] = returns all fields (NOT RECOMMENDED - use only when you need complete objects)
+                - ["id", "name"] = returns only specified fields (RECOMMENDED)
 
                 Examples:
-                - For counting: 'id' (minimal payload)
-                - For listings: 'id,name,status'
-                - For IP addresses: 'address,dns_name,description'
+                - For counting: ["id"] (minimal payload)
+                - For listings: ["id", "name", "status"]
+                - For IP addresses: ["address", "dns_name", "description"]
 
                 Uses NetBox's native field filtering via ?fields= parameter.
                 **Always specify only the fields you actually need.**
 
         brief: returns only a minimal representation of each object in the response.
-               This is useful when you need only a list of available objects without any related data.
 
         limit: Maximum results to return (default 5, max 100)
-               Start with default, increase only if needed
 
         offset: Skip this many results for pagination (default 0)
-                Example: offset=0 (page 1), offset=5 (page 2), offset=10 (page 3)
 
         ordering: Fields used to determine sort order of results.
                   Field names may be prefixed with '-' to invert the sort order.
@@ -323,21 +323,10 @@ def _netbox_get_objects_impl(
                   - 'name' (alphabetical by name)
                   - '-id' (ordered by ID descending)
                   - 'facility,-name' (by facility, then by name descending)
-                  - '' (default NetBox ordering)
 
 
     Returns:
-        Paginated response dict with the following structure:
-            - count: Total number of objects matching the query
-                     ALWAYS REFER TO THIS FIELD FOR THE TOTAL NUMBER OF OBJECTS MATCHING THE QUERY
-            - next: URL to next page (or null if no more pages)
-                    ALWAYS REFER TO THIS FIELD FOR THE NEXT PAGE OF RESULTS
-            - previous: URL to previous page (or null if on first page)
-                        ALWAYS REFER TO THIS FIELD FOR THE PREVIOUS PAGE OF RESULTS
-            - results: Array of objects for this page
-                       ALWAYS REFER TO THIS FIELD FOR THE OBJECTS ON THIS PAGE
-
-    ENSURE YOU ARE AWARE THE RESULTS ARE PAGINATED BEFORE PROVIDING RESPONSE TO THE USER.
+        Paginated response dict with count / next / previous / results.
 
     Valid object_type values:
 
@@ -348,30 +337,25 @@ def _netbox_get_objects_impl(
     See NetBox API documentation for filtering options for each object type.
     """
 )
+
+
 def netbox_get_objects(
     object_type: str,
-    filters: str = "{}",
-    fields: str = "",
+    filters: dict[str, Any] | None = None,
+    fields: list[str] | None = None,
     brief: bool = False,
-    # `float` (not `int`) is a workaround for n8n's MCP client, whose mapTypes
-    # table has no entry for JSON Schema "integer". See n8n#19835 and #58.
-    limit: Annotated[float, Field(default=5.0, ge=1.0, le=100.0)] = 5.0,
-    offset: Annotated[float, Field(default=0.0, ge=0.0)] = 0.0,
+    limit: Annotated[int, Field(ge=1, le=100)] = 5,
+    offset: Annotated[int, Field(ge=0)] = 0,
     ordering: str = "",
-):
-    """
-    Get objects from NetBox based on their type and filters
-    """
-    filters_dict = _parse_filters(filters)
-    fields_list = _parse_list_param(fields)
-
+) -> Any:
+    """Strict-mode wrapper (default). Takes native Python types."""
     return _netbox_get_objects_impl(
         object_type=object_type,
-        filters=filters_dict,
-        fields=fields_list,
+        filters=filters or {},
+        fields=fields or [],
         brief=brief,
-        limit=int(limit),
-        offset=int(offset),
+        limit=limit,
+        offset=offset,
         ordering=ordering,
     )
 
@@ -401,45 +385,29 @@ def _netbox_get_object_by_id_impl(
     return netbox.get(full_endpoint, params=params, fallback_endpoint=full_fallback)
 
 
-@mcp.tool
 def netbox_get_object_by_id(
     object_type: str,
-    # `float` (not `int`) is a workaround for n8n's MCP client, whose mapTypes
-    # table has no entry for JSON Schema "integer". See n8n#19835 and #58.
-    object_id: float,
-    fields: str = "",
+    object_id: int,
+    fields: list[str] | None = None,
     brief: bool = False,
-):
-    """
+) -> Any:
+    """Strict-mode wrapper for netbox_get_object_by_id.
+
     Get detailed information about a specific NetBox object by its ID.
 
     Args:
-        object_type: String representing the NetBox object type (e.g. "dcim.device", "ipam.ipaddress")
+        object_type: String representing the NetBox object type (e.g. "dcim.device")
         object_id: The numeric ID of the object
-        fields: Comma-separated string of specific fields to return
-                **IMPORTANT: ALWAYS USE THIS PARAMETER TO MINIMIZE TOKEN USAGE**
-                Field filtering reduces response payload by 80-90% and is critical for performance.
-
-                - Empty string '' = returns all fields (NOT RECOMMENDED - use only when you need complete objects)
-                - 'id,name' = returns only specified fields (RECOMMENDED)
-
-                Examples:
-                - For basic info: 'id,name,status'
-                - For devices: 'id,name,status,site'
-                - For IP addresses: 'address,dns_name,vrf,status'
-
-                Uses NetBox's native field filtering via ?fields= parameter.
-                **Always specify only the fields you actually need.**
-        brief: returns only a minimal representation of the object in the response.
-               This is useful when you need only a summary of the object without any related data.
+        fields: List of specific fields to return (e.g. ["id", "name", "status"])
+        brief: Return only a minimal representation
 
     Returns:
         Object dict (complete or with only requested fields based on fields parameter)
     """
-    fields_list = _parse_list_param(fields)
+    fields_list = fields or []
     return _netbox_get_object_by_id_impl(
         object_type=object_type,
-        object_id=int(object_id),
+        object_id=object_id,
         fields=fields_list,
         brief=brief,
     )
@@ -454,64 +422,18 @@ def _netbox_get_changelogs_impl(filters: dict[str, Any]) -> Any:
     return netbox.get("core/object-changes", params=filters)
 
 
-@mcp.tool
-def netbox_get_changelogs(filters: str = "{}"):
-    """
+def netbox_get_changelogs(filters: dict[str, Any] | None = None) -> Any:
+    """Strict-mode wrapper for netbox_get_changelogs.
+
     Get object change records (changelogs) from NetBox based on filters.
 
     Args:
-        filters: JSON string of filters to apply to the API call based on the NetBox API filtering options
+        filters: Dict of filters to apply to the API call.
 
     Returns:
-        Paginated response dict with the following structure:
-            - count: Total number of changelog entries matching the query
-                     ALWAYS REFER TO THIS FIELD FOR THE TOTAL NUMBER OF CHANGELOG ENTRIES MATCHING THE QUERY
-            - next: URL to next page (or null if no more pages)
-                    ALWAYS REFER TO THIS FIELD FOR THE NEXT PAGE OF RESULTS
-            - previous: URL to previous page (or null if on first page)
-                        ALWAYS REFER TO THIS FIELD FOR THE PREVIOUS PAGE OF RESULTS
-            - results: Array of changelog entries for this page
-                       ALWAYS REFER TO THIS FIELD FOR THE CHANGELOG ENTRIES ON THIS PAGE
-
-    Filtering options include:
-    - user_id: Filter by user ID who made the change
-    - user: Filter by username who made the change
-    - changed_object_type_id: Filter by numeric ContentType ID (e.g., 21 for dcim.device)
-                              Note: This expects a numeric ID, not an object type string
-    - changed_object_id: Filter by ID of the changed object
-    - object_repr: Filter by object representation (usually contains object name)
-    - action: Filter by action type (created, updated, deleted)
-    - time_before: Filter for changes made before a given time (ISO 8601 format)
-    - time_after: Filter for changes made after a given time (ISO 8601 format)
-    - q: Search term to filter by object representation
-
-    Examples:
-    To find all changes made to a specific object by ID:
-    '{"changed_object_id": 123}'
-
-    To find changes by object name pattern:
-    '{"object_repr": "router-01"}'
-
-    To find all deletions in the last 24 hours:
-    '{"action": "delete", "time_after": "2023-01-01T00:00:00Z"}'
-
-    Each changelog entry contains:
-    - id: The unique identifier of the changelog entry
-    - user: The user who made the change
-    - user_name: The username of the user who made the change
-    - request_id: The unique identifier of the request that made the change
-    - action: The type of action performed (created, updated, deleted)
-    - changed_object_type: The type of object that was changed
-    - changed_object_id: The ID of the object that was changed
-    - object_repr: String representation of the changed object
-    - object_data: The object's data after the change (null for deletions)
-    - object_data_v2: Enhanced data representation
-    - prechange_data: The object's data before the change (null for creations)
-    - postchange_data: The object's data after the change (null for deletions)
-    - time: The timestamp when the change was made
+        Paginated response dict.
     """
-    filters_dict = _parse_filters(filters)
-    return _netbox_get_changelogs_impl(filters_dict)
+    return _netbox_get_changelogs_impl(filters or {})
 
 
 def _netbox_search_objects_impl(
@@ -549,8 +471,8 @@ def _netbox_search_objects_impl(
     return results
 
 
-@mcp.tool(
-    description="""
+_NETBOX_SEARCH_OBJECTS_DESCRIPTION = (
+    """
     Perform global search across NetBox infrastructure.
 
     Searches names, descriptions, IP addresses, serial numbers, asset tags,
@@ -559,64 +481,33 @@ def _netbox_search_objects_impl(
     Args:
         query: Search term (device names, IPs, serial numbers, hostnames, site names)
                Examples: 'switch01', '192.168.1.1', 'NYC-DC1', 'SN123456'
-        object_types: Comma-separated string of types to search (optional)
+        object_types: List of types to search (optional)
                      Default: """
     + ",".join(DEFAULT_SEARCH_TYPES)
     + """
-                     Examples: 'dcim.device,ipam.ipaddress,dcim.site'
-        fields: Comma-separated string of specific fields to return (reduces response size) IT IS STRONGLY RECOMMENDED TO USE THIS PARAMETER TO MINIMIZE TOKEN USAGE.
-                - Empty string '' = returns all fields (no filtering)
-                - 'id,name' = returns only specified fields
-                Examples: 'id,name,status', 'address,dns_name'
-                Uses NetBox's native field filtering via ?fields= parameter
+                     Examples: ['dcim.device', 'ipam.ipaddress', 'dcim.site']
+        fields: List of specific fields to return (reduces response size)
+                Examples: ['id', 'name', 'status'], ['address', 'dns_name']
         limit: Max results per object type (default 5, max 100)
 
     Returns:
         Dictionary with object_type keys and list of matching objects.
-        All searched types present in result (empty list if no matches).
-
-    Example:
-        # Search for anything matching "switch"
-        results = netbox_search_objects('switch')
-        # Returns: {
-        #   'dcim.device': [{'id': 1, 'name': 'switch-01', ...}],
-        #   'dcim.site': [],
-        #   ...
-        # }
-
-        # Search for IP address
-        results = netbox_search_objects('192.168.1.100')
-        # Returns: {
-        #   'ipam.ipaddress': [{'id': 42, 'address': '192.168.1.100/24', ...}],
-        #   ...
-        # }
-
-        # Limit search to specific types with field projection
-        results = netbox_search_objects(
-            'NYC',
-            object_types='dcim.site,dcim.location',
-            fields='id,name,status'
-        )
     """
 )
+
+
 def netbox_search_objects(
     query: str,
-    object_types: str = "",
-    fields: str = "",
-    # `float` (not `int`) is a workaround for n8n's MCP client, whose mapTypes
-    # table has no entry for JSON Schema "integer". See n8n#19835 and #58.
-    limit: Annotated[float, Field(default=5.0, ge=1.0, le=100.0)] = 5.0,
+    object_types: list[str] | None = None,
+    fields: list[str] | None = None,
+    limit: Annotated[int, Field(ge=1, le=100)] = 5,
 ) -> dict[str, list[dict[str, Any]]]:
-    """
-    Perform global search across NetBox infrastructure.
-    """
-    search_types = _parse_list_param(object_types)
-    fields_list = _parse_list_param(fields)
+    """Strict-mode wrapper for netbox_search_objects."""
     return _netbox_search_objects_impl(
         query=query,
-        object_types=search_types,
-        fields=fields_list,
-        limit=int(limit),
+        object_types=object_types or [],
+        fields=fields or [],
+        limit=limit,
     )
 
 
@@ -636,6 +527,96 @@ def _get_endpoint_info(object_type: str) -> tuple[str, str | None]:
     """
     type_info = NETBOX_OBJECT_TYPES[object_type]
     return type_info["endpoint"], type_info.get("fallback_endpoint")
+
+
+def _register_strict_tools(mcp: FastMCP) -> None:
+    """Register strict-typed tools (native int/list/dict). Default mode."""
+    mcp.tool(description=_NETBOX_GET_OBJECTS_DESCRIPTION)(netbox_get_objects)
+    mcp.tool()(netbox_get_object_by_id)
+    mcp.tool()(netbox_get_changelogs)
+    mcp.tool(description=_NETBOX_SEARCH_OBJECTS_DESCRIPTION)(netbox_search_objects)
+
+
+def _register_compat_tools(mcp: FastMCP) -> None:
+    """Register string-typed tools for n8n AI Agent MCP client compatibility.
+
+    n8n's MCP client has a hardcoded mapTypes table that does not support
+    JSON Schema integer/array/object. See n8n-io/n8n#20682.
+    """
+
+    @mcp.tool(description=_NETBOX_GET_OBJECTS_DESCRIPTION)
+    def netbox_get_objects(
+        object_type: str,
+        filters: str = "{}",
+        fields: str = "",
+        brief: bool = False,
+        # float (not int) works around n8n's mapTypes missing "integer"
+        limit: Annotated[float, Field(default=5.0, ge=1.0, le=100.0)] = 5.0,
+        offset: Annotated[float, Field(default=0.0, ge=0.0)] = 0.0,
+        ordering: str = "",
+    ):
+        """n8n-compat wrapper. Parses strings to native types, calls impl."""
+        return _netbox_get_objects_impl(
+            object_type=object_type,
+            filters=_parse_filters(filters),
+            fields=_parse_list_param(fields),
+            brief=brief,
+            limit=int(limit),
+            offset=int(offset),
+            ordering=ordering,
+        )
+
+    @mcp.tool()
+    def netbox_get_object_by_id(
+        object_type: str,
+        object_id: float,
+        fields: str = "",
+        brief: bool = False,
+    ):
+        """n8n-compat wrapper for netbox_get_object_by_id."""
+        return _netbox_get_object_by_id_impl(
+            object_type=object_type,
+            object_id=int(object_id),
+            fields=_parse_list_param(fields),
+            brief=brief,
+        )
+
+    @mcp.tool()
+    def netbox_get_changelogs(filters: str = "{}"):
+        """n8n-compat wrapper for netbox_get_changelogs."""
+        return _netbox_get_changelogs_impl(_parse_filters(filters))
+
+    @mcp.tool(description=_NETBOX_SEARCH_OBJECTS_DESCRIPTION)
+    def netbox_search_objects(
+        query: str,
+        object_types: str = "",
+        fields: str = "",
+        limit: Annotated[float, Field(default=5.0, ge=1.0, le=100.0)] = 5.0,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """n8n-compat wrapper for netbox_search_objects."""
+        return _netbox_search_objects_impl(
+            query=query,
+            object_types=_parse_list_param(object_types),
+            fields=_parse_list_param(fields),
+            limit=int(limit),
+        )
+
+
+def create_mcp(n8n_compat: bool) -> FastMCP:
+    """Create a FastMCP instance with tools registered for the given mode.
+
+    Args:
+        n8n_compat: If True, register string-typed tool wrappers for the n8n
+                    AI Agent MCP client. If False (default), register
+                    strict JSON Schema types (integer/array/object) as
+                    consumed by most clients (Claude, Cursor, Cline, etc.).
+    """
+    mcp = FastMCP("NetBox")
+    if n8n_compat:
+        _register_compat_tools(mcp)
+    else:
+        _register_strict_tools(mcp)
+    return mcp
 
 
 def main() -> None:
@@ -687,6 +668,10 @@ def main() -> None:
     except Exception as e:
         logger.error(f"Failed to initialize NetBox client: {e}")
         sys.exit(1)
+
+    mcp = create_mcp(n8n_compat=settings.n8n_compat)
+    if settings.n8n_compat:
+        logger.info("n8n compatibility mode ENABLED (string-typed tool parameters)")
 
     try:
         if settings.transport == "stdio":

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -221,6 +221,44 @@ def validate_filters(filters: dict[str, Any]) -> None:
             )
 
 
+def _netbox_get_objects_impl(
+    object_type: str,
+    filters: dict[str, Any],
+    fields: list[str],
+    brief: bool,
+    limit: int,
+    offset: int,
+    ordering: str = "",
+) -> Any:
+    """Shared business logic for netbox_get_objects. Takes native Python types.
+
+    Called from both strict and compat tool wrappers. No schema concerns; no
+    parsing; no string handling.
+    """
+    if object_type not in NETBOX_OBJECT_TYPES:
+        valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
+        raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
+
+    validate_filters(filters)
+
+    endpoint, fallback = _get_endpoint_info(object_type)
+
+    params = filters.copy()
+    params["limit"] = limit
+    params["offset"] = offset
+
+    if fields:
+        params["fields"] = ",".join(fields)
+
+    if brief:
+        params["brief"] = "1"
+
+    if ordering and ordering.strip():
+        params["ordering"] = ordering
+
+    return netbox.get(endpoint, params=params, fallback_endpoint=fallback)
+
+
 @mcp.tool(
     description="""
     Get objects from NetBox based on their type and filters
@@ -312,38 +350,43 @@ def netbox_get_objects(
     """
     Get objects from NetBox based on their type and filters
     """
-    # Validate object_type exists in mapping
+    filters_dict = _parse_filters(filters)
+    fields_list = _parse_list_param(fields)
+
+    return _netbox_get_objects_impl(
+        object_type=object_type,
+        filters=filters_dict,
+        fields=fields_list,
+        brief=brief,
+        limit=int(limit),
+        offset=int(offset),
+        ordering=ordering,
+    )
+
+
+def _netbox_get_object_by_id_impl(
+    object_type: str,
+    object_id: int,
+    fields: list[str],
+    brief: bool,
+) -> Any:
+    """Shared business logic for netbox_get_object_by_id. Takes native types."""
     if object_type not in NETBOX_OBJECT_TYPES:
         valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
         raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
 
-    # Parse parameters - accept both string (n8n) and native types (Claude) for backward compatibility
-    filters_dict = _parse_filters(filters)
-    fields_list = _parse_list_param(fields)
-
-    # Validate filter patterns
-    validate_filters(filters_dict)
-
-    # Get API endpoint and fallback from mapping
     endpoint, fallback = _get_endpoint_info(object_type)
+    full_endpoint = f"{endpoint}/{object_id}"
+    full_fallback = f"{fallback}/{object_id}" if fallback else None
 
-    # Build params with pagination (parameters override filters dict)
-    # Convert float to int for NetBox API compatibility
-    params = filters_dict.copy()
-    params["limit"] = int(limit)
-    params["offset"] = int(offset)
-
-    if fields_list:
-        params["fields"] = ",".join(fields_list)
+    params: dict[str, Any] = {}
+    if fields:
+        params["fields"] = ",".join(fields)
 
     if brief:
         params["brief"] = "1"
 
-    if ordering and ordering.strip():
-        params["ordering"] = ordering
-
-    # Make API call
-    return netbox.get(endpoint, params=params, fallback_endpoint=fallback)
+    return netbox.get(full_endpoint, params=params, fallback_endpoint=full_fallback)
 
 
 @mcp.tool
@@ -381,28 +424,22 @@ def netbox_get_object_by_id(
     Returns:
         Object dict (complete or with only requested fields based on fields parameter)
     """
-    # Validate object_type exists in mapping
-    if object_type not in NETBOX_OBJECT_TYPES:
-        valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
-        raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
-
-    # Parse fields - accept both string (n8n) and list (Claude) for backward compatibility
     fields_list = _parse_list_param(fields)
+    return _netbox_get_object_by_id_impl(
+        object_type=object_type,
+        object_id=int(object_id),
+        fields=fields_list,
+        brief=brief,
+    )
 
-    # Get API endpoint and fallback from mapping
-    # Convert float to int for NetBox API compatibility
-    endpoint, fallback = _get_endpoint_info(object_type)
-    full_endpoint = f"{endpoint}/{int(object_id)}"
-    full_fallback = f"{fallback}/{int(object_id)}" if fallback else None
 
-    params = {}
-    if fields_list:
-        params["fields"] = ",".join(fields_list)
+def _netbox_get_changelogs_impl(filters: dict[str, Any]) -> Any:
+    """Shared business logic for netbox_get_changelogs. Takes native Python types.
 
-    if brief:
-        params["brief"] = "1"
-
-    return netbox.get(full_endpoint, params=params, fallback_endpoint=full_fallback)
+    Called from both strict and compat tool wrappers. No schema concerns; no
+    parsing; no string handling.
+    """
+    return netbox.get("core/object-changes", params=filters)
 
 
 @mcp.tool
@@ -461,13 +498,43 @@ def netbox_get_changelogs(filters: str = "{}"):
     - postchange_data: The object's data after the change (null for deletions)
     - time: The timestamp when the change was made
     """
-    # Parse filters - accept both string (n8n) and dict (Claude) for backward compatibility
     filters_dict = _parse_filters(filters)
+    return _netbox_get_changelogs_impl(filters_dict)
 
-    endpoint = "core/object-changes"
 
-    # Make API call
-    return netbox.get(endpoint, params=filters_dict)
+def _netbox_search_objects_impl(
+    query: str,
+    object_types: list[str],
+    fields: list[str],
+    limit: int,
+) -> dict[str, list[dict[str, Any]]]:
+    """Shared business logic for netbox_search_objects. Takes native types."""
+    search_types = object_types or DEFAULT_SEARCH_TYPES
+
+    for obj_type in search_types:
+        if obj_type not in NETBOX_OBJECT_TYPES:
+            valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
+            raise ValueError(f"Invalid object_type '{obj_type}'. Must be one of:\n{valid_types}")
+
+    results: dict[str, list[dict[str, Any]]] = {obj_type: [] for obj_type in search_types}
+
+    for obj_type in search_types:
+        try:
+            endpoint, fallback = _get_endpoint_info(obj_type)
+            response = netbox.get(
+                endpoint,
+                params={
+                    "q": query,
+                    "limit": limit,
+                    "fields": ",".join(fields) if fields else None,
+                },
+                fallback_endpoint=fallback,
+            )
+            results[obj_type] = response.get("results", [])
+        except Exception:  # noqa: S112 - intentional error-resilient search
+            continue
+
+    return results
 
 
 @mcp.tool(
@@ -531,39 +598,14 @@ def netbox_search_objects(
     """
     Perform global search across NetBox infrastructure.
     """
-    # Parse parameters - accept both string (n8n) and list (Claude) for backward compatibility
-    search_types = _parse_list_param(object_types) or DEFAULT_SEARCH_TYPES
+    search_types = _parse_list_param(object_types)
     fields_list = _parse_list_param(fields)
-
-    # Validate all object types exist in mapping
-    for obj_type in search_types:
-        if obj_type not in NETBOX_OBJECT_TYPES:
-            valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
-            raise ValueError(f"Invalid object_type '{obj_type}'. Must be one of:\n{valid_types}")
-
-    results = {obj_type: [] for obj_type in search_types}
-
-    # Build results dictionary (error-resilient)
-    for obj_type in search_types:
-        try:
-            endpoint, fallback = _get_endpoint_info(obj_type)
-            response = netbox.get(
-                endpoint,
-                params={
-                    "q": query,
-                    "limit": int(limit),
-                    "fields": ",".join(fields_list) if fields_list else None,
-                },
-                fallback_endpoint=fallback,
-            )
-            # Extract results array from paginated response
-            results[obj_type] = response.get("results", [])
-        except Exception:  # noqa: S112 - intentional error-resilient search
-            # Continue searching other types if one fails
-            # results[obj_type] already has empty list
-            continue
-
-    return results
+    return _netbox_search_objects_impl(
+        query=query,
+        object_types=search_types,
+        fields=fields_list,
+        limit=int(limit),
+    )
 
 
 def _get_endpoint_info(object_type: str) -> tuple[str, str | None]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,6 +90,85 @@ def test_parse_cli_args_multiple():
         sys.argv = original_argv
 
 
+# ===== n8n Compatibility Flag Tests =====
+
+
+def test_settings_n8n_compat_defaults_false():
+    """Default value of n8n_compat is False (strict types are default)."""
+    settings = Settings(
+        netbox_url="https://netbox.example.com/",
+        netbox_token="test-token",
+        _env_file=None,
+    )
+    assert settings.n8n_compat is False
+
+
+def test_settings_n8n_compat_from_env():
+    """NETBOX_MCP_N8N_COMPAT=true env var enables compat mode."""
+    with patch.dict(
+        "os.environ",
+        {
+            "NETBOX_URL": "https://netbox.example.com/",
+            "NETBOX_TOKEN": "test-token",
+            "NETBOX_MCP_N8N_COMPAT": "true",
+        },
+        clear=True,
+    ):
+        settings = Settings(_env_file=None)
+        assert settings.n8n_compat is True
+
+
+def test_settings_n8n_compat_not_set_by_bare_env_var():
+    """Bare N8N_COMPAT env var is NOT recognised — only the prefixed form.
+
+    We intentionally do not accept a bare-name alias to avoid namespace
+    collisions in multi-service deploys.
+    """
+    with patch.dict(
+        "os.environ",
+        {
+            "NETBOX_URL": "https://netbox.example.com/",
+            "NETBOX_TOKEN": "test-token",
+            "N8N_COMPAT": "true",
+        },
+        clear=True,
+    ):
+        settings = Settings(_env_file=None)
+        assert settings.n8n_compat is False
+
+
+def test_settings_n8n_compat_appears_in_summary():
+    """get_effective_config_summary includes n8n_compat so it's logged at startup."""
+    settings = Settings(
+        netbox_url="https://netbox.example.com/",
+        netbox_token="test-token",
+        n8n_compat=True,
+    )
+    assert settings.get_effective_config_summary()["n8n_compat"] is True
+
+
+def test_parse_cli_args_n8n_compat_flag():
+    """--n8n-compat CLI flag is captured in the overlay."""
+    original_argv = sys.argv
+    try:
+        sys.argv = ["server.py", "--n8n-compat"]
+        result = parse_cli_args()
+        assert result["n8n_compat"] is True
+    finally:
+        sys.argv = original_argv
+
+
+def test_parse_cli_args_n8n_compat_default_absent():
+    """Without --n8n-compat, the key is absent from the overlay."""
+    original_argv = sys.argv
+    try:
+        sys.argv = ["server.py"]
+        result = parse_cli_args()
+        assert "n8n_compat" not in result
+    finally:
+        sys.argv = original_argv
+
+
 # ===== Logging Configuration Tests =====
 
 

--- a/tests/test_impl_parity.py
+++ b/tests/test_impl_parity.py
@@ -1,0 +1,126 @@
+"""Parity test: strict and compat wrappers must produce identical NetBox API calls.
+
+The impl function is shared, so the real risk surface is the compat wrapper's
+string-parsing step. Cases here exercise only inputs that are actually
+transformed (JSON <-> dict, CSV <-> list). Trivially equivalent numeric casts
+(limit=10 vs 10.0) are covered by unit tests elsewhere.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from fastmcp import Client
+
+from netbox_mcp_server.server import create_mcp
+
+EMPTY_RESPONSE = {"count": 0, "next": None, "previous": None, "results": []}
+
+
+async def _call(mcp, tool_name: str, arguments: dict):
+    async with Client(mcp) as client:
+        return await client.call_tool(tool_name, arguments)
+
+
+@pytest.mark.parametrize(
+    ("strict_kwargs", "compat_kwargs"),
+    [
+        # filters: dict <-> JSON string
+        (
+            {"object_type": "dcim.site", "filters": {"status": "active"}},
+            {"object_type": "dcim.site", "filters": '{"status": "active"}'},
+        ),
+        (
+            {"object_type": "dcim.site", "filters": {"name__ic": "router", "id__in": [1, 2, 3]}},
+            {"object_type": "dcim.site", "filters": '{"name__ic": "router", "id__in": [1, 2, 3]}'},
+        ),
+        # fields: list <-> CSV string
+        (
+            {"object_type": "dcim.site", "filters": {}, "fields": ["id", "name"]},
+            {"object_type": "dcim.site", "filters": "{}", "fields": "id,name"},
+        ),
+        # ordering: string in both modes (sanity — should be identical)
+        (
+            {"object_type": "dcim.site", "filters": {}, "ordering": "facility,-name"},
+            {"object_type": "dcim.site", "filters": "{}", "ordering": "facility,-name"},
+        ),
+        # n8n-style empty filter string: "null" in compat = {} in strict
+        (
+            {"object_type": "dcim.site", "filters": {}},
+            {"object_type": "dcim.site", "filters": "null"},
+        ),
+    ],
+)
+def test_get_objects_parity(strict_kwargs, compat_kwargs):
+    """Semantically equivalent inputs to both modes produce identical API params."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+
+        strict_mcp = create_mcp(n8n_compat=False)
+        asyncio.run(_call(strict_mcp, "netbox_get_objects", strict_kwargs))
+        strict_params = mock.get.call_args[1]["params"]
+
+        mock.reset_mock()
+        mock.get.return_value = EMPTY_RESPONSE
+
+        compat_mcp = create_mcp(n8n_compat=True)
+        asyncio.run(_call(compat_mcp, "netbox_get_objects", compat_kwargs))
+        compat_params = mock.get.call_args[1]["params"]
+
+    assert strict_params == compat_params, (
+        f"Mode divergence!\nstrict: {strict_params}\ncompat: {compat_params}"
+    )
+
+
+def test_search_objects_parity():
+    """Search tool: list[str] in strict <-> CSV in compat.
+
+    Asserts both modes searched the same number of object types (guards
+    against _parse_list_param silently dropping a type) and that the
+    outgoing API params are identical.
+    """
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+
+        strict_mcp = create_mcp(n8n_compat=False)
+        asyncio.run(
+            _call(
+                strict_mcp,
+                "netbox_search_objects",
+                {
+                    "query": "nyc",
+                    "object_types": ["dcim.site", "dcim.device"],
+                    "fields": ["id", "name"],
+                },
+            )
+        )
+        strict_call_count = mock.get.call_count
+        # Capture params from the last call; they're structurally identical per-type
+        # because _netbox_search_objects_impl builds the same {q, limit, fields} dict.
+        strict_params = mock.get.call_args[1]["params"]
+
+        mock.reset_mock()
+        mock.get.return_value = EMPTY_RESPONSE
+
+        compat_mcp = create_mcp(n8n_compat=True)
+        asyncio.run(
+            _call(
+                compat_mcp,
+                "netbox_search_objects",
+                {
+                    "query": "nyc",
+                    "object_types": "dcim.site,dcim.device",
+                    "fields": "id,name",
+                },
+            )
+        )
+        compat_call_count = mock.get.call_count
+        compat_params = mock.get.call_args[1]["params"]
+
+    assert strict_call_count == compat_call_count, (
+        f"Mode divergence in searched types!\n"
+        f"strict searched {strict_call_count} types; compat searched {compat_call_count}"
+    )
+    assert strict_params == compat_params, (
+        f"Mode divergence in API params!\nstrict: {strict_params}\ncompat: {compat_params}"
+    )

--- a/tests/test_impl_parity.py
+++ b/tests/test_impl_parity.py
@@ -39,11 +39,6 @@ async def _call(mcp, tool_name: str, arguments: dict):
             {"object_type": "dcim.site", "filters": {}, "fields": ["id", "name"]},
             {"object_type": "dcim.site", "filters": "{}", "fields": "id,name"},
         ),
-        # ordering: string in both modes (sanity — should be identical)
-        (
-            {"object_type": "dcim.site", "filters": {}, "ordering": "facility,-name"},
-            {"object_type": "dcim.site", "filters": "{}", "ordering": "facility,-name"},
-        ),
         # n8n-style empty filter string: "null" in compat = {} in strict
         (
             {"object_type": "dcim.site", "filters": {}},

--- a/tests/test_mcp_boundary.py
+++ b/tests/test_mcp_boundary.py
@@ -1,11 +1,14 @@
 """End-to-end tests through the FastMCP schema-validation boundary.
 
-All other tests call `tool.fn(...)`, which bypasses Pydantic's schema enforcement
-and directly invokes the Python function. These tests go through `Client.call_tool`,
-which is the path every real MCP client takes. They are the regression guard for
-the n8n compatibility fix (see #58): the tool schemas must advertise string types
-so n8n accepts them, and LLM clients must still work when they send strings or
-native numbers per that schema.
+Most other tests invoke the strict-mode wrappers directly (``tool_fn(...)``),
+bypassing Pydantic's schema enforcement. The tests in this file go through
+``Client.call_tool``, which is the path every real MCP client takes — the
+schema is enforced.
+
+The tests here exercise *compat-mode* behavior: the string-typed tool schemas
+n8n's MCP client requires. Strict-mode boundary coverage lives in Task 4's
+additions (see ``test_impl_parity.py`` and the strict-mode section below
+once added).
 """
 
 import asyncio
@@ -14,12 +17,13 @@ from unittest.mock import patch
 import pytest
 from fastmcp import Client
 
-from netbox_mcp_server.server import mcp
+from netbox_mcp_server.server import create_mcp
 
 EMPTY_RESPONSE = {"count": 0, "next": None, "previous": None, "results": []}
 
 
-async def _call(tool_name: str, arguments: dict):
+async def _call_compat(tool_name: str, arguments: dict):
+    mcp = create_mcp(n8n_compat=True)
     async with Client(mcp) as client:
         return await client.call_tool(tool_name, arguments)
 
@@ -29,7 +33,7 @@ def test_string_filters_accepted_through_mcp_boundary():
     with patch("netbox_mcp_server.server.netbox") as mock:
         mock.get.return_value = EMPTY_RESPONSE
         asyncio.run(
-            _call(
+            _call_compat(
                 "netbox_get_objects",
                 {"object_type": "dcim.site", "filters": '{"status": "active"}'},
             )
@@ -48,7 +52,7 @@ def test_dict_filters_rejected_through_mcp_boundary():
         mock.get.return_value = EMPTY_RESPONSE
         with pytest.raises(Exception, match="valid string"):
             asyncio.run(
-                _call(
+                _call_compat(
                     "netbox_get_objects",
                     {"object_type": "dcim.site", "filters": {"status": "active"}},
                 )
@@ -65,7 +69,7 @@ def test_integer_limit_accepted_and_coerced():
     with patch("netbox_mcp_server.server.netbox") as mock:
         mock.get.return_value = EMPTY_RESPONSE
         asyncio.run(
-            _call(
+            _call_compat(
                 "netbox_get_objects",
                 {"object_type": "dcim.site", "limit": 10},
             )
@@ -78,7 +82,7 @@ def test_integer_object_id_accepted_through_mcp_boundary():
     with patch("netbox_mcp_server.server.netbox") as mock:
         mock.get.return_value = {"id": 42, "name": "site-nyc"}
         asyncio.run(
-            _call(
+            _call_compat(
                 "netbox_get_object_by_id",
                 {"object_type": "dcim.site", "object_id": 42},
             )

--- a/tests/test_mcp_boundary.py
+++ b/tests/test_mcp_boundary.py
@@ -5,10 +5,9 @@ bypassing Pydantic's schema enforcement. The tests in this file go through
 ``Client.call_tool``, which is the path every real MCP client takes — the
 schema is enforced.
 
-The tests here exercise *compat-mode* behavior: the string-typed tool schemas
-n8n's MCP client requires. Strict-mode boundary coverage lives in Task 4's
-additions (see ``test_impl_parity.py`` and the strict-mode section below
-once added).
+Both modes are exercised: the compat-mode tests verify n8n's string-typed
+schema still works when ``n8n_compat=True``, and the strict-mode tests
+(default) verify that LLM clients can use native JSON types.
 """
 
 import asyncio
@@ -24,6 +23,12 @@ EMPTY_RESPONSE = {"count": 0, "next": None, "previous": None, "results": []}
 
 async def _call_compat(tool_name: str, arguments: dict):
     mcp = create_mcp(n8n_compat=True)
+    async with Client(mcp) as client:
+        return await client.call_tool(tool_name, arguments)
+
+
+async def _call_strict(tool_name: str, arguments: dict):
+    mcp = create_mcp(n8n_compat=False)
     async with Client(mcp) as client:
         return await client.call_tool(tool_name, arguments)
 
@@ -89,3 +94,64 @@ def test_integer_object_id_accepted_through_mcp_boundary():
         )
         called_endpoint = mock.get.call_args[0][0]
         assert called_endpoint.endswith("/42")
+
+
+# ===== Strict-mode (default) boundary tests =====
+
+
+def test_strict_dict_filters_accepted_through_mcp_boundary():
+    """Strict mode: clients may send native JSON objects as filters."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+        asyncio.run(
+            _call_strict(
+                "netbox_get_objects",
+                {"object_type": "dcim.site", "filters": {"status": "active"}},
+            )
+        )
+        params = mock.get.call_args[1]["params"]
+        assert params["status"] == "active"
+
+
+def test_strict_list_fields_accepted_through_mcp_boundary():
+    """Strict mode: clients may send native arrays for fields."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+        asyncio.run(
+            _call_strict(
+                "netbox_get_objects",
+                {
+                    "object_type": "dcim.site",
+                    "filters": {},
+                    "fields": ["id", "name"],
+                },
+            )
+        )
+        params = mock.get.call_args[1]["params"]
+        assert params["fields"] == "id,name"
+
+
+def test_strict_integer_limit_accepted():
+    """Strict mode: clients may send native integers for limit."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+        asyncio.run(
+            _call_strict(
+                "netbox_get_objects",
+                {"object_type": "dcim.site", "filters": {}, "limit": 10},
+            )
+        )
+        assert mock.get.call_args[1]["params"]["limit"] == 10
+
+
+def test_strict_string_filters_rejected_through_mcp_boundary():
+    """Strict mode: passing a JSON string as filters is rejected at the schema boundary."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+        with pytest.raises(Exception, match=r"valid dictionary"):
+            asyncio.run(
+                _call_strict(
+                    "netbox_get_objects",
+                    {"object_type": "dcim.site", "filters": '{"status": "active"}'},
+                )
+            )

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -117,6 +117,25 @@ def test_ordering_multiple_fields_comma_separated(mock_netbox):
 
 
 @patch("netbox_mcp_server.server.netbox")
+def test_ordering_list_joined_comma_separated(mock_netbox):
+    """List of strings should be joined with commas before being sent to the API.
+
+    Restores the pre-#61 contract: callers may pass ordering as a list.
+    """
+    mock_netbox.get.return_value = {
+        "count": 0,
+        "results": [],
+        "next": None,
+        "previous": None,
+    }
+
+    netbox_get_objects(object_type="dcim.site", filters={}, ordering=["facility", "-name"])
+
+    params = mock_netbox.get.call_args[1]["params"]
+    assert params["ordering"] == "facility,-name"
+
+
+@patch("netbox_mcp_server.server.netbox")
 def test_ordering_whitespace_only_omits_parameter(mock_netbox):
     """When ordering contains only whitespace, should not include ordering in API params."""
     mock_netbox.get.return_value = {

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -9,7 +9,7 @@ from netbox_mcp_server.server import netbox_get_objects
 
 
 def test_ordering_rejects_invalid_types():
-    """Ordering parameter should reject non-string types."""
+    """Ordering parameter should reject non-string types but accept strings."""
     ordering_annotation = netbox_get_objects.__annotations__["ordering"]
     adapter = TypeAdapter(ordering_annotation)
 
@@ -19,9 +19,8 @@ def test_ordering_rejects_invalid_types():
     with pytest.raises(ValidationError):
         adapter.validate_python({"field": "name"})
 
-    # Lists are no longer accepted (removed for n8n compatibility)
-    with pytest.raises(ValidationError):
-        adapter.validate_python(["name", "-id"])
+    # Plain strings accepted (multiple fields via comma-separated form)
+    assert adapter.validate_python("name,-id") == "name,-id"
 
 
 @patch("netbox_mcp_server.server.netbox")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -33,7 +33,7 @@ def test_limit_validation_rejects_invalid_values():
 def test_invalid_object_type_raises_error():
     """Invalid object type should raise ValueError with helpful message."""
     with pytest.raises(ValueError, match="Invalid object_type"):
-        netbox_search_objects(query="test", object_types="invalid_type_xyz")
+        netbox_search_objects(query="test", object_types=["invalid_type_xyz"])
 
 
 # ============================================================================
@@ -69,7 +69,7 @@ def test_custom_object_types_limits_search_scope(mock_netbox):
         "results": [],
     }
 
-    result = netbox_search_objects(query="test", object_types="dcim.device,dcim.site")
+    result = netbox_search_objects(query="test", object_types=["dcim.device", "dcim.site"])
 
     # Should only search specified types
     assert mock_netbox.get.call_count == 2
@@ -91,7 +91,9 @@ def test_field_projection_applied_to_queries(mock_netbox):
         "results": [],
     }
 
-    netbox_search_objects(query="test", object_types="dcim.device,dcim.site", fields="id,name")
+    netbox_search_objects(
+        query="test", object_types=["dcim.device", "dcim.site"], fields=["id", "name"]
+    )
 
     # All calls should include fields parameter
     for call_args in mock_netbox.get.call_args_list:
@@ -120,7 +122,9 @@ def test_result_structure_with_empty_and_populated_results(mock_netbox):
 
     mock_netbox.get.side_effect = mock_get_side_effect
 
-    result = netbox_search_objects(query="test", object_types="dcim.device,dcim.site,dcim.rack")
+    result = netbox_search_objects(
+        query="test", object_types=["dcim.device", "dcim.site", "dcim.rack"]
+    )
 
     # All types present
     assert set(result.keys()) == {"dcim.device", "dcim.site", "dcim.rack"}
@@ -154,7 +158,7 @@ def test_continues_searching_when_one_type_fails(mock_netbox):
 
     mock_netbox.get.side_effect = mock_get_side_effect
 
-    result = netbox_search_objects(query="test", object_types="dcim.device,dcim.site")
+    result = netbox_search_objects(query="test", object_types=["dcim.device", "dcim.site"])
 
     # Should continue despite error
     assert result["dcim.site"] == [{"id": 1, "name": "site01"}]
@@ -177,7 +181,7 @@ def test_api_parameters_passed_correctly(mock_netbox):
         "results": [],
     }
 
-    netbox_search_objects(query="switch01", object_types="dcim.device", fields="id", limit=25)
+    netbox_search_objects(query="switch01", object_types=["dcim.device"], fields=["id"], limit=25)
 
     call_args = mock_netbox.get.call_args
     params = call_args[1]["params"]
@@ -197,7 +201,7 @@ def test_uses_correct_api_endpoints(mock_netbox):
         "results": [],
     }
 
-    netbox_search_objects(query="test", object_types="dcim.device,ipam.ipaddress")
+    netbox_search_objects(query="test", object_types=["dcim.device", "ipam.ipaddress"])
 
     called_endpoints = [call[0][0] for call in mock_netbox.get.call_args_list]
     assert NETBOX_OBJECT_TYPES["dcim.device"]["endpoint"] in called_endpoints
@@ -234,7 +238,7 @@ def test_extracts_results_from_paginated_response(mock_netbox):
         ],
     }
 
-    result = netbox_search_objects(query="test", object_types="dcim.device")
+    result = netbox_search_objects(query="test", object_types=["dcim.device"])
 
     # Should return dict with object type as key
     assert "dcim.device" in result

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -249,3 +249,28 @@ def test_extracts_results_from_paginated_response(mock_netbox):
         {"id": 1, "name": "device01"},
         {"id": 2, "name": "device02"},
     ]
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_search_objects_strict_mode_accepts_lists(mock_netbox):
+    """Strict-mode netbox_search_objects accepts native list[str] for object_types and fields."""
+    mock_netbox.get.return_value = {
+        "count": 0,
+        "results": [],
+        "next": None,
+        "previous": None,
+    }
+
+    result = netbox_search_objects(
+        query="nyc",
+        object_types=["dcim.site"],
+        fields=["id", "name"],
+        limit=3,
+    )
+
+    assert isinstance(result, dict)
+    assert "dcim.site" in result
+    call_params = mock_netbox.get.call_args[1]["params"]
+    assert call_params["q"] == "nyc"
+    assert call_params["limit"] == 3
+    assert call_params["fields"] == "id,name"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -249,28 +249,3 @@ def test_extracts_results_from_paginated_response(mock_netbox):
         {"id": 1, "name": "device01"},
         {"id": 2, "name": "device02"},
     ]
-
-
-@patch("netbox_mcp_server.server.netbox")
-def test_search_objects_strict_mode_accepts_lists(mock_netbox):
-    """Strict-mode netbox_search_objects accepts native list[str] for object_types and fields."""
-    mock_netbox.get.return_value = {
-        "count": 0,
-        "results": [],
-        "next": None,
-        "previous": None,
-    }
-
-    result = netbox_search_objects(
-        query="nyc",
-        object_types=["dcim.site"],
-        fields=["id", "name"],
-        limit=3,
-    )
-
-    assert isinstance(result, dict)
-    assert "dcim.site" in result
-    call_params = mock_netbox.get.call_args[1]["params"]
-    assert call_params["q"] == "nyc"
-    assert call_params["limit"] == 3
-    assert call_params["fields"] == "id,name"

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -1,0 +1,43 @@
+"""Sanity checks that the flag flips the advertised tool schema.
+
+We deliberately do not exhaustively assert every property's type — that would
+test FastMCP's schema generation, not our code. One assertion per mode on the
+key type difference is enough.
+"""
+
+import asyncio
+
+from fastmcp import Client
+
+from netbox_mcp_server.server import create_mcp
+
+
+async def _get_filters_types(n8n_compat: bool) -> set[str]:
+    """Return the set of types accepted by the ``filters`` parameter schema.
+
+    Pydantic renders ``dict | None = None`` as ``anyOf: [{type: object}, {type: null}]``,
+    and ``str = "{}"`` as a single ``{type: string}``. Normalising to a set
+    lets each test assert the exact accepted type universe.
+    """
+    mcp = create_mcp(n8n_compat=n8n_compat)
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+        for tool in tools:
+            if tool.name == "netbox_get_objects":
+                schema = tool.inputSchema["properties"]["filters"]
+                if "anyOf" in schema:
+                    return {entry.get("type") for entry in schema["anyOf"]}
+                return {schema.get("type")}
+    raise AssertionError("netbox_get_objects not found in registered tools")
+
+
+def test_strict_mode_advertises_object_filters():
+    """Default mode advertises filters as JSON object (nullable). No strings allowed."""
+    types = asyncio.run(_get_filters_types(n8n_compat=False))
+    assert types == {"object", "null"}
+
+
+def test_compat_mode_advertises_string_filters():
+    """Compat mode advertises filters as a string only. No objects allowed."""
+    types = asyncio.run(_get_filters_types(n8n_compat=True))
+    assert types == {"string"}


### PR DESCRIPTION
## Summary

Corrects the regression introduced in #61 (merged 2026-04-20) by restoring strict JSON Schema types (`integer`/`array`/`object`) as the default tool schemas, and moving the string-based behavior behind an opt-in flag for n8n users.

- Default: `int`/`list`/`dict` parameters — clean schemas for Claude, Cursor,
  Cline, and other MCP clients.
- Opt-in via `NETBOX_MCP_N8N_COMPAT=true` or `--n8n-compat`: string-typed
  parameters matching n8n's `mapTypes` constraints.
- Shared `_impl` functions guarantee both wrappers produce identical NetBox
  API calls.
- New `test_impl_parity.py` is the load-bearing regression guard — asserts
  semantically equivalent inputs produce identical outgoing API params
  across modes.

## Test plan

- [x] `uv run pytest -q` — **112 passed** (99 baseline + 13 new)
- [x] `test_tool_registration.py` asserts `filters` schema flips between
      `{object, null}` (strict) and `{string}` (compat)
- [x] `test_impl_parity.py` asserts both modes produce identical API params
      for equivalent inputs, including `object_types` list-vs-CSV, and
      n8n-style empty-value strings (`"null"`)
- [x] `test_mcp_boundary.py` covers both modes through the FastMCP
      schema-validation boundary (dict filters accepted in strict, rejected
      in compat, and vice versa)
- [x] ruff check + ruff format — clean
- [ ] Manual verification with Claude Desktop (default mode) — native types
- [ ] Manual verification with n8n AI Agent (compat mode) — string types

## Upstream tracking

n8n-side fix: https://github.com/n8n-io/n8n/pull/20682 (open, unreviewed
since Oct 2025). Flag will be removed once that fix ships in an n8n release.

Related: n8n-io/n8n#19835, n8n-io/n8n#21569.