### PR TITLE
feat: add opt-in n8n compatibility mode (NETBOX_MCP_N8N_COMPAT / --n8n-compat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The server supports multiple configuration sources with the following precedence
 | `PORT` | Integer | `8000` | If HTTP | Port for HTTP server |
 | `VERIFY_SSL` | Boolean | `true` | No | Whether to verify SSL certificates |
 | `LOG_LEVEL` | `DEBUG` \| `INFO` \| `WARNING` \| `ERROR` \| `CRITICAL` | `INFO` | No | Logging verbosity |
+| `NETBOX_MCP_N8N_COMPAT` | Boolean | `false` | No | Enable n8n AI Agent MCP client compatibility mode (string-typed parameters). See [n8n Compatibility Mode](#n8n-compatibility-mode). |
 
 ### Transport Examples
 
@@ -250,6 +251,37 @@ uv run netbox-mcp-server --help
 uv run netbox-mcp-server --log-level DEBUG --no-verify-ssl  # Development
 uv run netbox-mcp-server --transport http --port 9000       # Custom HTTP port
 ```
+
+### n8n Compatibility Mode
+
+The n8n AI Agent MCP client does not currently support JSON Schema
+`integer`, `array`, or `object` parameter types — it has a hardcoded
+type-mapping table covering only `string`, `number`, `boolean`, and
+`json`. If you're connecting this server from n8n, enable compatibility
+mode:
+
+```bash
+# Via environment variable
+NETBOX_MCP_N8N_COMPAT=true uv run netbox-mcp-server
+
+# Or via CLI flag
+uv run netbox-mcp-server --n8n-compat
+```
+
+In compat mode:
+
+- `filters` is a JSON string (e.g. `'{"site_id": 1}'`) instead of an object
+- `fields`, `ordering`, and `object_types` are comma-separated strings instead of arrays
+- `limit`, `offset`, and `object_id` are `number` instead of `integer`
+
+**Upstream tracking:** A [community PR][n8n-pr] proposes the fix but has
+been unreviewed since October 2025. This flag will be removed once that
+fix (or equivalent) ships in an n8n release. See the relevant upstream
+reports: [n8n#19835][n8n-19835], [n8n#21569][n8n-21569].
+
+[n8n-pr]: https://github.com/n8n-io/n8n/pull/20682
+[n8n-19835]: https://github.com/n8n-io/n8n/issues/19835
+[n8n-21569]: https://github.com/n8n-io/n8n/issues/21569
 
 ## Docker Usage
 

--- a/src/netbox_mcp_server/config.py
+++ b/src/netbox_mcp_server/config.py
@@ -4,7 +4,7 @@ import logging
 import logging.config
 from typing import Any, Literal
 
-from pydantic import AnyUrl, SecretStr, field_validator, model_validator
+from pydantic import AnyUrl, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -42,6 +42,18 @@ class Settings(BaseSettings):
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
     """Logging verbosity level"""
 
+    # ===== n8n Compatibility =====
+    n8n_compat: bool = Field(
+        default=False,
+        validation_alias="NETBOX_MCP_N8N_COMPAT",
+        description=(
+            "Enable n8n AI Agent MCP client compatibility. Exposes tool "
+            "parameters as strings instead of native JSON Schema types "
+            "(integer/array/object). Required when connecting from n8n. "
+            "See n8n-io/n8n#20682."
+        ),
+    )
+
     # ===== Pydantic Configuration =====
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -71,6 +83,24 @@ class Settings(BaseSettings):
             )
         return v
 
+    @model_validator(mode="before")
+    @classmethod
+    def _map_n8n_compat_field_name(cls, values: Any) -> Any:
+        """Allow direct construction with n8n_compat= kwarg despite validation_alias.
+
+        pydantic-settings resolves env vars via the alias, but direct Python
+        callers (tests, library users) may pass n8n_compat= by field name.
+        This validator remaps the field name to the alias before validation
+        so both styles work without exposing N8N_COMPAT as an accepted env var.
+        """
+        if (
+            isinstance(values, dict)
+            and "n8n_compat" in values
+            and "NETBOX_MCP_N8N_COMPAT" not in values
+        ):
+            values["NETBOX_MCP_N8N_COMPAT"] = values.pop("n8n_compat")
+        return values
+
     @model_validator(mode="after")
     def validate_http_transport_requirements(self) -> "Settings":
         """No additional validation needed for HTTP transport; defaults are appropriate."""
@@ -91,6 +121,7 @@ class Settings(BaseSettings):
             "port": self.port if self.transport == "http" else "N/A",
             "verify_ssl": self.verify_ssl,
             "log_level": self.log_level,
+            "n8n_compat": self.n8n_compat,
         }
 
 

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -77,6 +77,16 @@ def parse_cli_args() -> dict[str, Any]:
         help="Logging verbosity level (default: INFO)",
     )
 
+    # n8n compatibility
+    parser.add_argument(
+        "--n8n-compat",
+        action="store_true",
+        dest="n8n_compat",
+        default=None,
+        help="Enable n8n AI Agent MCP client compatibility mode "
+        "(string-typed tool parameters). See README.",
+    )
+
     args: argparse.Namespace = parser.parse_args()
 
     overlay: dict[str, Any] = {}
@@ -94,6 +104,8 @@ def parse_cli_args() -> dict[str, Any]:
         overlay["verify_ssl"] = args.verify_ssl
     if args.log_level is not None:
         overlay["log_level"] = args.log_level
+    if args.n8n_compat is not None:
+        overlay["n8n_compat"] = args.n8n_compat
 
     return overlay
 

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -250,14 +250,18 @@ def _netbox_get_objects_impl(
     Called from both strict and compat tool wrappers. No schema concerns; no
     parsing; no string handling.
     """
+    # Validate object_type exists in mapping
     if object_type not in NETBOX_OBJECT_TYPES:
         valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
         raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
 
+    # Validate filter patterns
     validate_filters(filters)
 
+    # Get API endpoint and fallback from mapping
     endpoint, fallback = _get_endpoint_info(object_type)
 
+    # Build params with pagination (parameters override filters dict)
     params = filters.copy()
     params["limit"] = limit
     params["offset"] = offset
@@ -271,6 +275,7 @@ def _netbox_get_objects_impl(
     if ordering and ordering.strip():
         params["ordering"] = ordering
 
+    # Make API call
     return netbox.get(endpoint, params=params, fallback_endpoint=fallback)
 
 
@@ -280,31 +285,31 @@ _NETBOX_GET_OBJECTS_DESCRIPTION = (
 
     Args:
         object_type: String representing the NetBox object type (e.g. "dcim.device", "ipam.ipaddress")
-        filters: Filters to apply to the API call based on the NetBox API filtering options
+        filters: dict of filters to apply to the API call based on the NetBox API filtering options
 
                 FILTER RULES:
-                Valid: Direct fields like {"site_id": 1, "name": "router", "status": "active"}
-                Valid: Lookups like {"name__ic": "switch", "id__in": [1,2,3], "vid__gte": 100}
-                Invalid: Multi-hop like {"device__site_id": 1} - NOT supported
+                Valid: Direct fields like {'site_id': 1, 'name': 'router', 'status': 'active'}
+                Valid: Lookups like {'name__ic': 'switch', 'id__in': [1,2,3], 'vid__gte': 100}
+                Invalid: Multi-hop like {'device__site_id': 1} - NOT supported
 
                 Lookup suffixes: n, ic, nic, isw, nisw, iew, niew, ie, nie,
                                  empty, regex, iregex, lt, lte, gt, gte, in
 
                 Two-step pattern for cross-relationship queries:
-                  sites = netbox_get_objects('dcim.site', {"name": "NYC"})
-                  netbox_get_objects('dcim.device', {"site_id": sites[0]['id']})
+                  sites = netbox_get_objects('dcim.site', {'name': 'NYC'})
+                  netbox_get_objects('dcim.device', {'site_id': sites[0]['id']})
 
-        fields: List of specific fields to return
+        fields: Optional list of specific fields to return
                 **IMPORTANT: ALWAYS USE THIS PARAMETER TO MINIMIZE TOKEN USAGE**
                 Field filtering significantly reduces response payload and is critical for performance.
 
                 - None or [] = returns all fields (NOT RECOMMENDED - use only when you need complete objects)
-                - ["id", "name"] = returns only specified fields (RECOMMENDED)
+                - ['id', 'name'] = returns only specified fields (RECOMMENDED)
 
                 Examples:
-                - For counting: ["id"] (minimal payload)
-                - For listings: ["id", "name", "status"]
-                - For IP addresses: ["address", "dns_name", "description"]
+                - For counting: ['id'] (minimal payload)
+                - For listings: ['id', 'name', 'status']
+                - For IP addresses: ['address', 'dns_name', 'description']
 
                 Uses NetBox's native field filtering via ?fields= parameter.
                 **Always specify only the fields you actually need.**
@@ -320,14 +325,12 @@ _NETBOX_GET_OBJECTS_DESCRIPTION = (
 
         ordering: Fields used to determine sort order of results.
                   Field names may be prefixed with '-' to invert the sort order.
-                  Multiple fields may be specified with a list of strings or a
-                  comma-separated string.
+                  Multiple fields may be specified with a list of strings.
 
                   Examples:
                   - 'name' (alphabetical by name)
                   - '-id' (ordered by ID descending)
                   - ['facility', '-name'] (by facility, then by name descending)
-                  - 'facility,-name' (same as above, comma-separated form)
                   - None, '' or [] (default NetBox ordering)
 
 
@@ -357,18 +360,20 @@ _NETBOX_GET_OBJECTS_DESCRIPTION = (
 
 def netbox_get_objects(
     object_type: str,
-    filters: dict[str, Any] | None = None,
+    filters: dict,
     fields: list[str] | None = None,
     brief: bool = False,
-    limit: Annotated[int, Field(ge=1, le=100)] = 5,
-    offset: Annotated[int, Field(ge=0)] = 0,
+    limit: Annotated[int, Field(default=5, ge=1, le=100)] = 5,
+    offset: Annotated[int, Field(default=0, ge=0)] = 0,
     ordering: str | list[str] | None = None,
 ) -> Any:
-    """Strict-mode wrapper (default). Takes native Python types."""
-    ordering_str = ",".join(ordering) if isinstance(ordering, list) else ordering or ""
+    """
+    Get objects from NetBox based on their type and filters
+    """
+    ordering_str = ",".join(ordering) if isinstance(ordering, list) else (ordering or "")
     return _netbox_get_objects_impl(
         object_type=object_type,
-        filters=filters or {},
+        filters=filters,
         fields=fields or [],
         brief=brief,
         limit=limit,
@@ -384,10 +389,12 @@ def _netbox_get_object_by_id_impl(
     brief: bool,
 ) -> Any:
     """Shared business logic for netbox_get_object_by_id. Takes native types."""
+    # Validate object_type exists in mapping
     if object_type not in NETBOX_OBJECT_TYPES:
         valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
         raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
 
+    # Get API endpoint and fallback from mapping
     endpoint, fallback = _get_endpoint_info(object_type)
     full_endpoint = f"{endpoint}/{object_id}"
     full_fallback = f"{fallback}/{object_id}" if fallback else None
@@ -408,15 +415,28 @@ def netbox_get_object_by_id(
     fields: list[str] | None = None,
     brief: bool = False,
 ) -> Any:
-    """Strict-mode wrapper for netbox_get_object_by_id.
-
+    """
     Get detailed information about a specific NetBox object by its ID.
 
     Args:
-        object_type: String representing the NetBox object type (e.g. "dcim.device")
+        object_type: String representing the NetBox object type (e.g. "dcim.device", "ipam.ipaddress")
         object_id: The numeric ID of the object
-        fields: List of specific fields to return (e.g. ["id", "name", "status"])
-        brief: Return only a minimal representation
+        fields: Optional list of specific fields to return
+                **IMPORTANT: ALWAYS USE THIS PARAMETER TO MINIMIZE TOKEN USAGE**
+                Field filtering reduces response payload by 80-90% and is critical for performance.
+
+                - None or [] = returns all fields (NOT RECOMMENDED - use only when you need complete objects)
+                - ['id', 'name'] = returns only specified fields (RECOMMENDED)
+
+                Examples:
+                - For basic info: ['id', 'name', 'status']
+                - For devices: ['id', 'name', 'status', 'site']
+                - For IP addresses: ['address', 'dns_name', 'vrf', 'status']
+
+                Uses NetBox's native field filtering via ?fields= parameter.
+                **Always specify only the fields you actually need.**
+        brief: returns only a minimal representation of the object in the response.
+               This is useful when you need only a summary of the object without any related data.
 
     Returns:
         Object dict (complete or with only requested fields based on fields parameter)
@@ -436,6 +456,7 @@ def _netbox_get_changelogs_impl(filters: dict[str, Any]) -> Any:
     Called from both strict and compat tool wrappers. No schema concerns; no
     parsing; no string handling.
     """
+    # Make API call
     return netbox.get("core/object-changes", params=filters)
 
 
@@ -495,9 +516,62 @@ _NETBOX_GET_CHANGELOGS_DESCRIPTION = """
     """
 
 
-def netbox_get_changelogs(filters: dict[str, Any] | None = None) -> Any:
-    """Strict-mode wrapper for netbox_get_changelogs. See tool description."""
-    return _netbox_get_changelogs_impl(filters or {})
+def netbox_get_changelogs(filters: dict) -> Any:
+    """
+    Get object change records (changelogs) from NetBox based on filters.
+
+    Args:
+        filters: dict of filters to apply to the API call based on the NetBox API filtering options
+
+    Returns:
+        Paginated response dict with the following structure:
+            - count: Total number of changelog entries matching the query
+                     ALWAYS REFER TO THIS FIELD FOR THE TOTAL NUMBER OF CHANGELOG ENTRIES MATCHING THE QUERY
+            - next: URL to next page (or null if no more pages)
+                    ALWAYS REFER TO THIS FIELD FOR THE NEXT PAGE OF RESULTS
+            - previous: URL to previous page (or null if on first page)
+                        ALWAYS REFER TO THIS FIELD FOR THE PREVIOUS PAGE OF RESULTS
+            - results: Array of changelog entries for this page
+                       ALWAYS REFER TO THIS FIELD FOR THE CHANGELOG ENTRIES ON THIS PAGE
+
+    Filtering options include:
+    - user_id: Filter by user ID who made the change
+    - user: Filter by username who made the change
+    - changed_object_type_id: Filter by numeric ContentType ID (e.g., 21 for dcim.device)
+                              Note: This expects a numeric ID, not an object type string
+    - changed_object_id: Filter by ID of the changed object
+    - object_repr: Filter by object representation (usually contains object name)
+    - action: Filter by action type (created, updated, deleted)
+    - time_before: Filter for changes made before a given time (ISO 8601 format)
+    - time_after: Filter for changes made after a given time (ISO 8601 format)
+    - q: Search term to filter by object representation
+
+    Examples:
+    To find all changes made to a specific object by ID:
+    {"changed_object_id": 123}
+
+    To find changes by object name pattern:
+    {"object_repr": "router-01"}
+
+    To find all deletions in the last 24 hours:
+    {"action": "delete", "time_after": "2023-01-01T00:00:00Z"}
+
+    Each changelog entry contains:
+    - id: The unique identifier of the changelog entry
+    - user: The user who made the change
+    - user_name: The username of the user who made the change
+    - request_id: The unique identifier of the request that made the change
+    - action: The type of action performed (created, updated, deleted)
+    - changed_object_type: The type of object that was changed
+    - changed_object_id: The ID of the object that was changed
+    - object_repr: String representation of the changed object
+    - object_data: The object's data after the change (null for deletions)
+    - object_data_v2: Enhanced data representation
+    - prechange_data: The object's data before the change (null for creations)
+    - postchange_data: The object's data after the change (null for deletions)
+    - time: The timestamp when the change was made
+    """
+    return _netbox_get_changelogs_impl(filters)
 
 
 def _netbox_search_objects_impl(
@@ -509,6 +583,7 @@ def _netbox_search_objects_impl(
     """Shared business logic for netbox_search_objects. Takes native types."""
     search_types = object_types or DEFAULT_SEARCH_TYPES
 
+    # Validate all object types exist in mapping
     for obj_type in search_types:
         if obj_type not in NETBOX_OBJECT_TYPES:
             valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
@@ -516,6 +591,7 @@ def _netbox_search_objects_impl(
 
     results: dict[str, list[dict[str, Any]]] = {obj_type: [] for obj_type in search_types}
 
+    # Build results dictionary (error-resilient)
     for obj_type in search_types:
         try:
             endpoint, fallback = _get_endpoint_info(obj_type)
@@ -528,8 +604,11 @@ def _netbox_search_objects_impl(
                 },
                 fallback_endpoint=fallback,
             )
+            # Extract results array from paginated response
             results[obj_type] = response.get("results", [])
         except Exception:  # noqa: S112 - intentional error-resilient search
+            # Continue searching other types if one fails
+            # results[obj_type] already has empty list
             continue
 
     return results
@@ -545,17 +624,44 @@ _NETBOX_SEARCH_OBJECTS_DESCRIPTION = (
     Args:
         query: Search term (device names, IPs, serial numbers, hostnames, site names)
                Examples: 'switch01', '192.168.1.1', 'NYC-DC1', 'SN123456'
-        object_types: List of types to search (optional)
-                     Default: """
-    + ",".join(DEFAULT_SEARCH_TYPES)
-    + """
+        object_types: Limit search to specific types (optional)
+                     Default: ["""
+    + "', '".join(DEFAULT_SEARCH_TYPES)
+    + """]
                      Examples: ['dcim.device', 'ipam.ipaddress', 'dcim.site']
-        fields: List of specific fields to return (reduces response size)
+        fields: Optional list of specific fields to return (reduces response size) IT IS STRONGLY RECOMMENDED TO USE THIS PARAMETER TO MINIMIZE TOKEN USAGE.
+                - None or [] = returns all fields (no filtering)
+                - ['id', 'name'] = returns only specified fields
                 Examples: ['id', 'name', 'status'], ['address', 'dns_name']
+                Uses NetBox's native field filtering via ?fields= parameter
         limit: Max results per object type (default 5, max 100)
 
     Returns:
         Dictionary with object_type keys and list of matching objects.
+        All searched types present in result (empty list if no matches).
+
+    Example:
+        # Search for anything matching "switch"
+        results = netbox_search_objects('switch')
+        # Returns: {
+        #   'dcim.device': [{'id': 1, 'name': 'switch-01', ...}],
+        #   'dcim.site': [],
+        #   ...
+        # }
+
+        # Search for IP address
+        results = netbox_search_objects('192.168.1.100')
+        # Returns: {
+        #   'ipam.ipaddress': [{'id': 42, 'address': '192.168.1.100/24', ...}],
+        #   ...
+        # }
+
+        # Limit search to specific types with field projection
+        results = netbox_search_objects(
+            'NYC',
+            object_types=['dcim.site', 'dcim.location'],
+            fields=['id', 'name', 'status']
+        )
     """
 )
 
@@ -564,9 +670,11 @@ def netbox_search_objects(
     query: str,
     object_types: list[str] | None = None,
     fields: list[str] | None = None,
-    limit: Annotated[int, Field(ge=1, le=100)] = 5,
-) -> dict[str, list[dict[str, Any]]]:
-    """Strict-mode wrapper for netbox_search_objects."""
+    limit: Annotated[int, Field(default=5, ge=1, le=100)] = 5,
+) -> dict[str, list[dict]]:
+    """
+    Perform global search across NetBox infrastructure.
+    """
     return _netbox_search_objects_impl(
         query=query,
         object_types=object_types or [],

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -275,8 +275,9 @@ def _netbox_get_objects_impl(
     if brief:
         params["brief"] = "1"
 
-    if ordering and ordering.strip():
-        params["ordering"] = ordering
+    cleaned_ordering = ordering.strip()
+    if cleaned_ordering:
+        params["ordering"] = cleaned_ordering
 
     # Make API call
     return netbox.get(endpoint, params=params, fallback_endpoint=fallback)
@@ -533,8 +534,12 @@ def _netbox_search_objects_impl(
     fields: list[str],
     limit: int,
 ) -> dict[str, list[dict[str, Any]]]:
-    """Shared business logic for netbox_search_objects. Takes native types."""
-    search_types = object_types or DEFAULT_SEARCH_TYPES
+    """Shared business logic for netbox_search_objects. Takes a resolved list of
+    native types; wrappers own the ``DEFAULT_SEARCH_TYPES`` fallback so that
+    strict mode can preserve the old ``None``-vs-``[]`` contract while compat
+    mode (which cannot express ``None``) maps empty-string input to defaults.
+    """
+    search_types = object_types
 
     # Validate all object types exist in mapping
     for obj_type in search_types:
@@ -628,9 +633,12 @@ def netbox_search_objects(
     """
     Perform global search across NetBox infrastructure.
     """
+    # Preserve the pre-refactor contract: None means "use defaults";
+    # an explicit empty list means "search nothing".
+    search_types = object_types if object_types is not None else DEFAULT_SEARCH_TYPES
     return _netbox_search_objects_impl(
         query=query,
-        object_types=object_types or [],
+        object_types=search_types,
         fields=fields or [],
         limit=limit,
     )
@@ -710,7 +718,10 @@ def _register_compat_tools(mcp: FastMCP) -> None:
     @mcp.tool(description=_compat_description(_NETBOX_GET_OBJECT_BY_ID_DESCRIPTION))
     def netbox_get_object_by_id(
         object_type: str,
-        object_id: float,
+        # multiple_of=1 rejects fractional floats (42.5) at the schema layer
+        # so we never silently truncate to the wrong object. Integer-valued
+        # floats (42.0, which is what n8n sends) still pass.
+        object_id: Annotated[float, Field(multiple_of=1.0)],
         fields: str = "",
         brief: bool = False,
     ) -> Any:
@@ -735,9 +746,12 @@ def _register_compat_tools(mcp: FastMCP) -> None:
         limit: Annotated[float, Field(default=5.0, ge=1.0, le=100.0)] = 5.0,
     ) -> dict[str, list[dict[str, Any]]]:
         """n8n-compat wrapper for netbox_search_objects. See description for details."""
+        # Compat clients can't send None, so empty/blank input maps to defaults.
+        parsed_types = _parse_list_param(object_types)
+        search_types = parsed_types or DEFAULT_SEARCH_TYPES
         return _netbox_search_objects_impl(
             query=query,
-            object_types=_parse_list_param(object_types),
+            object_types=search_types,
             fields=_parse_list_param(fields),
             limit=int(limit),
         )

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import sys
 from typing import Annotated, Any
@@ -122,11 +123,60 @@ DEFAULT_SEARCH_TYPES = [
     "virtualization.virtualmachine",  # VM names
 ]
 
-mcp = FastMCP("NetBox")
 netbox = None
 
+# Some MCP clients (e.g., n8n) send literal strings for empty optional parameters
+_EMPTY_STRING_VALUES = {"undefined", "null", "none"}
 
-def validate_filters(filters: dict) -> None:
+
+def _is_empty_string(value: str) -> bool:
+    """Check if a string represents an empty value (including n8n-style nulls)."""
+    stripped = value.strip()
+    return not stripped or stripped.lower() in _EMPTY_STRING_VALUES
+
+
+def _parse_filters(filters: str | dict[str, Any] | None) -> dict[str, Any]:
+    """Parse filters parameter from JSON string or dict (n8n-compat mode only).
+
+    Called from the compat-mode tool wrappers, which advertise ``filters`` as
+    a JSON string via the MCP schema. Accepts a dict too as a convenience for
+    direct Python callers, but MCP clients in compat mode always send strings.
+
+    Strict-mode (default) wrappers take native dicts and do not call this
+    helper.
+    """
+    if filters is None:
+        return {}
+    if isinstance(filters, dict):
+        return filters
+    if _is_empty_string(filters):
+        return {}
+    try:
+        return json.loads(filters.strip())
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid filters JSON: {e}") from e
+
+
+def _parse_list_param(value: str | list[str] | None) -> list[str]:
+    """Parse a list parameter from a comma-separated string or list (n8n-compat mode only).
+
+    Called from the compat-mode tool wrappers, which advertise list-like
+    parameters as comma-separated strings via the MCP schema. Accepts a list
+    as a convenience for direct Python callers.
+
+    Strict-mode (default) wrappers take native ``list[str]`` and do not call
+    this helper.
+    """
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if _is_empty_string(value):
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def validate_filters(filters: dict[str, Any]) -> None:
     """
     Validate that filters don't use multi-hop relationship traversal.
 
@@ -186,37 +236,75 @@ def validate_filters(filters: dict) -> None:
             )
 
 
-@mcp.tool(
-    description="""
+def _netbox_get_objects_impl(
+    object_type: str,
+    filters: dict[str, Any],
+    fields: list[str],
+    brief: bool,
+    limit: int,
+    offset: int,
+    ordering: str = "",
+) -> Any:
+    """Shared business logic for netbox_get_objects. Takes native Python types.
+
+    Called from both strict and compat tool wrappers. No schema concerns; no
+    parsing; no string handling.
+    """
+    if object_type not in NETBOX_OBJECT_TYPES:
+        valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
+        raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
+
+    validate_filters(filters)
+
+    endpoint, fallback = _get_endpoint_info(object_type)
+
+    params = filters.copy()
+    params["limit"] = limit
+    params["offset"] = offset
+
+    if fields:
+        params["fields"] = ",".join(fields)
+
+    if brief:
+        params["brief"] = "1"
+
+    if ordering and ordering.strip():
+        params["ordering"] = ordering
+
+    return netbox.get(endpoint, params=params, fallback_endpoint=fallback)
+
+
+_NETBOX_GET_OBJECTS_DESCRIPTION = (
+    """
     Get objects from NetBox based on their type and filters
 
     Args:
         object_type: String representing the NetBox object type (e.g. "dcim.device", "ipam.ipaddress")
-        filters: dict of filters to apply to the API call based on the NetBox API filtering options
+        filters: Filters to apply to the API call based on the NetBox API filtering options
 
                 FILTER RULES:
-                Valid: Direct fields like {'site_id': 1, 'name': 'router', 'status': 'active'}
-                Valid: Lookups like {'name__ic': 'switch', 'id__in': [1,2,3], 'vid__gte': 100}
-                Invalid: Multi-hop like {'device__site_id': 1} - NOT supported
+                Valid: Direct fields like {"site_id": 1, "name": "router", "status": "active"}
+                Valid: Lookups like {"name__ic": "switch", "id__in": [1,2,3], "vid__gte": 100}
+                Invalid: Multi-hop like {"device__site_id": 1} - NOT supported
 
                 Lookup suffixes: n, ic, nic, isw, nisw, iew, niew, ie, nie,
                                  empty, regex, iregex, lt, lte, gt, gte, in
 
                 Two-step pattern for cross-relationship queries:
-                  sites = netbox_get_objects('dcim.site', {'name': 'NYC'})
-                  netbox_get_objects('dcim.device', {'site_id': sites[0]['id']})
+                  sites = netbox_get_objects('dcim.site', {"name": "NYC"})
+                  netbox_get_objects('dcim.device', {"site_id": sites[0]['id']})
 
-        fields: Optional list of specific fields to return
+        fields: List of specific fields to return
                 **IMPORTANT: ALWAYS USE THIS PARAMETER TO MINIMIZE TOKEN USAGE**
                 Field filtering significantly reduces response payload and is critical for performance.
 
                 - None or [] = returns all fields (NOT RECOMMENDED - use only when you need complete objects)
-                - ['id', 'name'] = returns only specified fields (RECOMMENDED)
+                - ["id", "name"] = returns only specified fields (RECOMMENDED)
 
                 Examples:
-                - For counting: ['id'] (minimal payload)
-                - For listings: ['id', 'name', 'status']
-                - For IP addresses: ['address', 'dns_name', 'description']
+                - For counting: ["id"] (minimal payload)
+                - For listings: ["id", "name", "status"]
+                - For IP addresses: ["address", "dns_name", "description"]
 
                 Uses NetBox's native field filtering via ?fields= parameter.
                 **Always specify only the fields you actually need.**
@@ -232,12 +320,14 @@ def validate_filters(filters: dict) -> None:
 
         ordering: Fields used to determine sort order of results.
                   Field names may be prefixed with '-' to invert the sort order.
-                  Multiple fields may be specified with a list of strings.
+                  Multiple fields may be specified with a list of strings or a
+                  comma-separated string.
 
                   Examples:
                   - 'name' (alphabetical by name)
                   - '-id' (ordered by ID descending)
                   - ['facility', '-name'] (by facility, then by name descending)
+                  - 'facility,-name' (same as above, comma-separated form)
                   - None, '' or [] (default NetBox ordering)
 
 
@@ -263,94 +353,46 @@ def validate_filters(filters: dict) -> None:
     See NetBox API documentation for filtering options for each object type.
     """
 )
+
+
 def netbox_get_objects(
     object_type: str,
-    filters: dict,
+    filters: dict[str, Any] | None = None,
     fields: list[str] | None = None,
     brief: bool = False,
-    limit: Annotated[int, Field(default=5, ge=1, le=100)] = 5,
-    offset: Annotated[int, Field(default=0, ge=0)] = 0,
+    limit: Annotated[int, Field(ge=1, le=100)] = 5,
+    offset: Annotated[int, Field(ge=0)] = 0,
     ordering: str | list[str] | None = None,
-):
-    """
-    Get objects from NetBox based on their type and filters
-    """
-    # Validate object_type exists in mapping
-    if object_type not in NETBOX_OBJECT_TYPES:
-        valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
-        raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
-
-    # Validate filter patterns
-    validate_filters(filters)
-
-    # Get API endpoint and fallback from mapping
-    endpoint, fallback = _get_endpoint_info(object_type)
-
-    # Build params with pagination (parameters override filters dict)
-    params = filters.copy()
-    params["limit"] = limit
-    params["offset"] = offset
-
-    if fields:
-        params["fields"] = ",".join(fields)
-
-    if brief:
-        params["brief"] = "1"
-
-    if ordering:
-        if isinstance(ordering, list):
-            ordering = ",".join(ordering)
-        if ordering.strip() != "":
-            params["ordering"] = ordering
-
-    # Make API call
-    return netbox.get(endpoint, params=params, fallback_endpoint=fallback)
+) -> Any:
+    """Strict-mode wrapper (default). Takes native Python types."""
+    ordering_str = ",".join(ordering) if isinstance(ordering, list) else ordering or ""
+    return _netbox_get_objects_impl(
+        object_type=object_type,
+        filters=filters or {},
+        fields=fields or [],
+        brief=brief,
+        limit=limit,
+        offset=offset,
+        ordering=ordering_str,
+    )
 
 
-@mcp.tool
-def netbox_get_object_by_id(
+def _netbox_get_object_by_id_impl(
     object_type: str,
     object_id: int,
-    fields: list[str] | None = None,
-    brief: bool = False,
-):
-    """
-    Get detailed information about a specific NetBox object by its ID.
-
-    Args:
-        object_type: String representing the NetBox object type (e.g. "dcim.device", "ipam.ipaddress")
-        object_id: The numeric ID of the object
-        fields: Optional list of specific fields to return
-                **IMPORTANT: ALWAYS USE THIS PARAMETER TO MINIMIZE TOKEN USAGE**
-                Field filtering reduces response payload by 80-90% and is critical for performance.
-
-                - None or [] = returns all fields (NOT RECOMMENDED - use only when you need complete objects)
-                - ['id', 'name'] = returns only specified fields (RECOMMENDED)
-
-                Examples:
-                - For basic info: ['id', 'name', 'status']
-                - For devices: ['id', 'name', 'status', 'site']
-                - For IP addresses: ['address', 'dns_name', 'vrf', 'status']
-
-                Uses NetBox's native field filtering via ?fields= parameter.
-                **Always specify only the fields you actually need.**
-        brief: returns only a minimal representation of the object in the response.
-               This is useful when you need only a summary of the object without any related data.
-
-    Returns:
-        Object dict (complete or with only requested fields based on fields parameter)
-    """
-    # Validate object_type exists in mapping
+    fields: list[str],
+    brief: bool,
+) -> Any:
+    """Shared business logic for netbox_get_object_by_id. Takes native types."""
     if object_type not in NETBOX_OBJECT_TYPES:
         valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
         raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
 
-    # Get API endpoint and fallback from mapping
     endpoint, fallback = _get_endpoint_info(object_type)
     full_endpoint = f"{endpoint}/{object_id}"
     full_fallback = f"{fallback}/{object_id}" if fallback else None
 
-    params = {}
+    params: dict[str, Any] = {}
     if fields:
         params["fields"] = ",".join(fields)
 
@@ -360,9 +402,44 @@ def netbox_get_object_by_id(
     return netbox.get(full_endpoint, params=params, fallback_endpoint=full_fallback)
 
 
-@mcp.tool
-def netbox_get_changelogs(filters: dict):
+def netbox_get_object_by_id(
+    object_type: str,
+    object_id: int,
+    fields: list[str] | None = None,
+    brief: bool = False,
+) -> Any:
+    """Strict-mode wrapper for netbox_get_object_by_id.
+
+    Get detailed information about a specific NetBox object by its ID.
+
+    Args:
+        object_type: String representing the NetBox object type (e.g. "dcim.device")
+        object_id: The numeric ID of the object
+        fields: List of specific fields to return (e.g. ["id", "name", "status"])
+        brief: Return only a minimal representation
+
+    Returns:
+        Object dict (complete or with only requested fields based on fields parameter)
     """
+    fields_list = fields or []
+    return _netbox_get_object_by_id_impl(
+        object_type=object_type,
+        object_id=object_id,
+        fields=fields_list,
+        brief=brief,
+    )
+
+
+def _netbox_get_changelogs_impl(filters: dict[str, Any]) -> Any:
+    """Shared business logic for netbox_get_changelogs. Takes native Python types.
+
+    Called from both strict and compat tool wrappers. No schema concerns; no
+    parsing; no string handling.
+    """
+    return netbox.get("core/object-changes", params=filters)
+
+
+_NETBOX_GET_CHANGELOGS_DESCRIPTION = """
     Get object change records (changelogs) from NetBox based on filters.
 
     Args:
@@ -416,82 +493,29 @@ def netbox_get_changelogs(filters: dict):
     - postchange_data: The object's data after the change (null for deletions)
     - time: The timestamp when the change was made
     """
-    endpoint = "core/object-changes"
-
-    # Make API call
-    return netbox.get(endpoint, params=filters)
 
 
-@mcp.tool(
-    description="""
-    Perform global search across NetBox infrastructure.
+def netbox_get_changelogs(filters: dict[str, Any] | None = None) -> Any:
+    """Strict-mode wrapper for netbox_get_changelogs. See tool description."""
+    return _netbox_get_changelogs_impl(filters or {})
 
-    Searches names, descriptions, IP addresses, serial numbers, asset tags,
-    and other key fields across multiple object types.
 
-    Args:
-        query: Search term (device names, IPs, serial numbers, hostnames, site names)
-               Examples: 'switch01', '192.168.1.1', 'NYC-DC1', 'SN123456'
-        object_types: Limit search to specific types (optional)
-                     Default: ["""
-    + "', '".join(DEFAULT_SEARCH_TYPES)
-    + """]
-                     Examples: ['dcim.device', 'ipam.ipaddress', 'dcim.site']
-        fields: Optional list of specific fields to return (reduces response size) IT IS STRONGLY RECOMMENDED TO USE THIS PARAMETER TO MINIMIZE TOKEN USAGE.
-                - None or [] = returns all fields (no filtering)
-                - ['id', 'name'] = returns only specified fields
-                Examples: ['id', 'name', 'status'], ['address', 'dns_name']
-                Uses NetBox's native field filtering via ?fields= parameter
-        limit: Max results per object type (default 5, max 100)
-
-    Returns:
-        Dictionary with object_type keys and list of matching objects.
-        All searched types present in result (empty list if no matches).
-
-    Example:
-        # Search for anything matching "switch"
-        results = netbox_search_objects('switch')
-        # Returns: {
-        #   'dcim.device': [{'id': 1, 'name': 'switch-01', ...}],
-        #   'dcim.site': [],
-        #   ...
-        # }
-
-        # Search for IP address
-        results = netbox_search_objects('192.168.1.100')
-        # Returns: {
-        #   'ipam.ipaddress': [{'id': 42, 'address': '192.168.1.100/24', ...}],
-        #   ...
-        # }
-
-        # Limit search to specific types with field projection
-        results = netbox_search_objects(
-            'NYC',
-            object_types=['dcim.site', 'dcim.location'],
-            fields=['id', 'name', 'status']
-        )
-    """
-)
-def netbox_search_objects(
+def _netbox_search_objects_impl(
     query: str,
-    object_types: list[str] | None = None,
-    fields: list[str] | None = None,
-    limit: Annotated[int, Field(default=5, ge=1, le=100)] = 5,
-) -> dict[str, list[dict]]:
-    """
-    Perform global search across NetBox infrastructure.
-    """
-    search_types = object_types if object_types is not None else DEFAULT_SEARCH_TYPES
+    object_types: list[str],
+    fields: list[str],
+    limit: int,
+) -> dict[str, list[dict[str, Any]]]:
+    """Shared business logic for netbox_search_objects. Takes native types."""
+    search_types = object_types or DEFAULT_SEARCH_TYPES
 
-    # Validate all object types exist in mapping
     for obj_type in search_types:
         if obj_type not in NETBOX_OBJECT_TYPES:
             valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
             raise ValueError(f"Invalid object_type '{obj_type}'. Must be one of:\n{valid_types}")
 
-    results = {obj_type: [] for obj_type in search_types}
+    results: dict[str, list[dict[str, Any]]] = {obj_type: [] for obj_type in search_types}
 
-    # Build results dictionary (error-resilient)
     for obj_type in search_types:
         try:
             endpoint, fallback = _get_endpoint_info(obj_type)
@@ -504,14 +528,51 @@ def netbox_search_objects(
                 },
                 fallback_endpoint=fallback,
             )
-            # Extract results array from paginated response
             results[obj_type] = response.get("results", [])
         except Exception:  # noqa: S112 - intentional error-resilient search
-            # Continue searching other types if one fails
-            # results[obj_type] already has empty list
             continue
 
     return results
+
+
+_NETBOX_SEARCH_OBJECTS_DESCRIPTION = (
+    """
+    Perform global search across NetBox infrastructure.
+
+    Searches names, descriptions, IP addresses, serial numbers, asset tags,
+    and other key fields across multiple object types.
+
+    Args:
+        query: Search term (device names, IPs, serial numbers, hostnames, site names)
+               Examples: 'switch01', '192.168.1.1', 'NYC-DC1', 'SN123456'
+        object_types: List of types to search (optional)
+                     Default: """
+    + ",".join(DEFAULT_SEARCH_TYPES)
+    + """
+                     Examples: ['dcim.device', 'ipam.ipaddress', 'dcim.site']
+        fields: List of specific fields to return (reduces response size)
+                Examples: ['id', 'name', 'status'], ['address', 'dns_name']
+        limit: Max results per object type (default 5, max 100)
+
+    Returns:
+        Dictionary with object_type keys and list of matching objects.
+    """
+)
+
+
+def netbox_search_objects(
+    query: str,
+    object_types: list[str] | None = None,
+    fields: list[str] | None = None,
+    limit: Annotated[int, Field(ge=1, le=100)] = 5,
+) -> dict[str, list[dict[str, Any]]]:
+    """Strict-mode wrapper for netbox_search_objects."""
+    return _netbox_search_objects_impl(
+        query=query,
+        object_types=object_types or [],
+        fields=fields or [],
+        limit=limit,
+    )
 
 
 def _get_endpoint_info(object_type: str) -> tuple[str, str | None]:
@@ -530,6 +591,96 @@ def _get_endpoint_info(object_type: str) -> tuple[str, str | None]:
     """
     type_info = NETBOX_OBJECT_TYPES[object_type]
     return type_info["endpoint"], type_info.get("fallback_endpoint")
+
+
+def _register_strict_tools(mcp: FastMCP) -> None:
+    """Register strict-typed tools (native int/list/dict). Default mode."""
+    mcp.tool(description=_NETBOX_GET_OBJECTS_DESCRIPTION)(netbox_get_objects)
+    mcp.tool()(netbox_get_object_by_id)
+    mcp.tool(description=_NETBOX_GET_CHANGELOGS_DESCRIPTION)(netbox_get_changelogs)
+    mcp.tool(description=_NETBOX_SEARCH_OBJECTS_DESCRIPTION)(netbox_search_objects)
+
+
+def _register_compat_tools(mcp: FastMCP) -> None:
+    """Register string-typed tools for n8n AI Agent MCP client compatibility.
+
+    n8n's MCP client has a hardcoded mapTypes table that does not support
+    JSON Schema integer/array/object. See n8n-io/n8n#20682.
+    """
+
+    @mcp.tool(description=_NETBOX_GET_OBJECTS_DESCRIPTION)
+    def netbox_get_objects(
+        object_type: str,
+        filters: str = "{}",
+        fields: str = "",
+        brief: bool = False,
+        # float (not int) works around n8n's mapTypes missing "integer"
+        limit: Annotated[float, Field(default=5.0, ge=1.0, le=100.0)] = 5.0,
+        offset: Annotated[float, Field(default=0.0, ge=0.0)] = 0.0,
+        ordering: str = "",
+    ) -> Any:
+        """n8n-compat wrapper. Parses strings to native types, calls impl."""
+        return _netbox_get_objects_impl(
+            object_type=object_type,
+            filters=_parse_filters(filters),
+            fields=_parse_list_param(fields),
+            brief=brief,
+            limit=int(limit),
+            offset=int(offset),
+            ordering=ordering,
+        )
+
+    @mcp.tool()
+    def netbox_get_object_by_id(
+        object_type: str,
+        object_id: float,
+        fields: str = "",
+        brief: bool = False,
+    ) -> Any:
+        """n8n-compat wrapper for netbox_get_object_by_id."""
+        return _netbox_get_object_by_id_impl(
+            object_type=object_type,
+            object_id=int(object_id),
+            fields=_parse_list_param(fields),
+            brief=brief,
+        )
+
+    @mcp.tool(description=_NETBOX_GET_CHANGELOGS_DESCRIPTION)
+    def netbox_get_changelogs(filters: str = "{}") -> Any:
+        """n8n-compat wrapper for netbox_get_changelogs."""
+        return _netbox_get_changelogs_impl(_parse_filters(filters))
+
+    @mcp.tool(description=_NETBOX_SEARCH_OBJECTS_DESCRIPTION)
+    def netbox_search_objects(
+        query: str,
+        object_types: str = "",
+        fields: str = "",
+        limit: Annotated[float, Field(default=5.0, ge=1.0, le=100.0)] = 5.0,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """n8n-compat wrapper for netbox_search_objects."""
+        return _netbox_search_objects_impl(
+            query=query,
+            object_types=_parse_list_param(object_types),
+            fields=_parse_list_param(fields),
+            limit=int(limit),
+        )
+
+
+def create_mcp(n8n_compat: bool) -> FastMCP:
+    """Create a FastMCP instance with tools registered for the given mode.
+
+    Args:
+        n8n_compat: If True, register string-typed tool wrappers for the n8n
+                    AI Agent MCP client. If False (default), register
+                    strict JSON Schema types (integer/array/object) as
+                    consumed by most clients (Claude, Cursor, Cline, etc.).
+    """
+    mcp = FastMCP("NetBox")
+    if n8n_compat:
+        _register_compat_tools(mcp)
+    else:
+        _register_strict_tools(mcp)
+    return mcp
 
 
 def main() -> None:
@@ -581,6 +732,10 @@ def main() -> None:
     except Exception as e:
         logger.error(f"Failed to initialize NetBox client: {e}")
         sys.exit(1)
+
+    mcp = create_mcp(n8n_compat=settings.n8n_compat)
+    if settings.n8n_compat:
+        logger.info("n8n compatibility mode ENABLED (string-typed tool parameters)")
 
     try:
         if settings.transport == "stdio":

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -152,9 +152,12 @@ def _parse_filters(filters: str | dict[str, Any] | None) -> dict[str, Any]:
     if _is_empty_string(filters):
         return {}
     try:
-        return json.loads(filters.strip())
+        parsed = json.loads(filters.strip())
     except json.JSONDecodeError as e:
         raise ValueError(f"Invalid filters JSON: {e}") from e
+    if not isinstance(parsed, dict):
+        raise ValueError(f"filters must be a JSON object, got {type(parsed).__name__}")
+    return parsed
 
 
 def _parse_list_param(value: str | list[str] | None) -> list[str]:
@@ -409,13 +412,7 @@ def _netbox_get_object_by_id_impl(
     return netbox.get(full_endpoint, params=params, fallback_endpoint=full_fallback)
 
 
-def netbox_get_object_by_id(
-    object_type: str,
-    object_id: int,
-    fields: list[str] | None = None,
-    brief: bool = False,
-) -> Any:
-    """
+_NETBOX_GET_OBJECT_BY_ID_DESCRIPTION = """
     Get detailed information about a specific NetBox object by its ID.
 
     Args:
@@ -441,6 +438,15 @@ def netbox_get_object_by_id(
     Returns:
         Object dict (complete or with only requested fields based on fields parameter)
     """
+
+
+def netbox_get_object_by_id(
+    object_type: str,
+    object_id: int,
+    fields: list[str] | None = None,
+    brief: bool = False,
+) -> Any:
+    """Strict-mode wrapper for netbox_get_object_by_id. See description for details."""
     fields_list = fields or []
     return _netbox_get_object_by_id_impl(
         object_type=object_type,
@@ -517,60 +523,7 @@ _NETBOX_GET_CHANGELOGS_DESCRIPTION = """
 
 
 def netbox_get_changelogs(filters: dict) -> Any:
-    """
-    Get object change records (changelogs) from NetBox based on filters.
-
-    Args:
-        filters: dict of filters to apply to the API call based on the NetBox API filtering options
-
-    Returns:
-        Paginated response dict with the following structure:
-            - count: Total number of changelog entries matching the query
-                     ALWAYS REFER TO THIS FIELD FOR THE TOTAL NUMBER OF CHANGELOG ENTRIES MATCHING THE QUERY
-            - next: URL to next page (or null if no more pages)
-                    ALWAYS REFER TO THIS FIELD FOR THE NEXT PAGE OF RESULTS
-            - previous: URL to previous page (or null if on first page)
-                        ALWAYS REFER TO THIS FIELD FOR THE PREVIOUS PAGE OF RESULTS
-            - results: Array of changelog entries for this page
-                       ALWAYS REFER TO THIS FIELD FOR THE CHANGELOG ENTRIES ON THIS PAGE
-
-    Filtering options include:
-    - user_id: Filter by user ID who made the change
-    - user: Filter by username who made the change
-    - changed_object_type_id: Filter by numeric ContentType ID (e.g., 21 for dcim.device)
-                              Note: This expects a numeric ID, not an object type string
-    - changed_object_id: Filter by ID of the changed object
-    - object_repr: Filter by object representation (usually contains object name)
-    - action: Filter by action type (created, updated, deleted)
-    - time_before: Filter for changes made before a given time (ISO 8601 format)
-    - time_after: Filter for changes made after a given time (ISO 8601 format)
-    - q: Search term to filter by object representation
-
-    Examples:
-    To find all changes made to a specific object by ID:
-    {"changed_object_id": 123}
-
-    To find changes by object name pattern:
-    {"object_repr": "router-01"}
-
-    To find all deletions in the last 24 hours:
-    {"action": "delete", "time_after": "2023-01-01T00:00:00Z"}
-
-    Each changelog entry contains:
-    - id: The unique identifier of the changelog entry
-    - user: The user who made the change
-    - user_name: The username of the user who made the change
-    - request_id: The unique identifier of the request that made the change
-    - action: The type of action performed (created, updated, deleted)
-    - changed_object_type: The type of object that was changed
-    - changed_object_id: The ID of the object that was changed
-    - object_repr: String representation of the changed object
-    - object_data: The object's data after the change (null for deletions)
-    - object_data_v2: Enhanced data representation
-    - prechange_data: The object's data before the change (null for creations)
-    - postchange_data: The object's data after the change (null for deletions)
-    - time: The timestamp when the change was made
-    """
+    """Strict-mode wrapper for netbox_get_changelogs. See description for details."""
     return _netbox_get_changelogs_impl(filters)
 
 
@@ -701,10 +654,26 @@ def _get_endpoint_info(object_type: str) -> tuple[str, str | None]:
     return type_info["endpoint"], type_info.get("fallback_endpoint")
 
 
+_COMPAT_PREAMBLE = """
+    n8n compatibility mode — parameter shapes differ from the examples below:
+      - `filters` is a JSON STRING (double-quoted), e.g. '{"site_id": 1}' — not a dict literal.
+      - `fields`, `ordering`, `object_types` are COMMA-SEPARATED STRINGS, e.g. "id,name" — not arrays.
+      - `limit`, `offset`, `object_id` are NUMBERS (floats accepted; server coerces to int).
+    The examples in the description below illustrate the conceptual data shapes. Serialize dicts
+    as proper JSON (double quotes) and arrays as CSV strings before sending.
+
+"""
+
+
+def _compat_description(base: str) -> str:
+    """Prefix a base description with the n8n compat-mode parameter-shape preamble."""
+    return _COMPAT_PREAMBLE + base
+
+
 def _register_strict_tools(mcp: FastMCP) -> None:
     """Register strict-typed tools (native int/list/dict). Default mode."""
     mcp.tool(description=_NETBOX_GET_OBJECTS_DESCRIPTION)(netbox_get_objects)
-    mcp.tool()(netbox_get_object_by_id)
+    mcp.tool(description=_NETBOX_GET_OBJECT_BY_ID_DESCRIPTION)(netbox_get_object_by_id)
     mcp.tool(description=_NETBOX_GET_CHANGELOGS_DESCRIPTION)(netbox_get_changelogs)
     mcp.tool(description=_NETBOX_SEARCH_OBJECTS_DESCRIPTION)(netbox_search_objects)
 
@@ -716,7 +685,7 @@ def _register_compat_tools(mcp: FastMCP) -> None:
     JSON Schema integer/array/object. See n8n-io/n8n#20682.
     """
 
-    @mcp.tool(description=_NETBOX_GET_OBJECTS_DESCRIPTION)
+    @mcp.tool(description=_compat_description(_NETBOX_GET_OBJECTS_DESCRIPTION))
     def netbox_get_objects(
         object_type: str,
         filters: str = "{}",
@@ -727,7 +696,7 @@ def _register_compat_tools(mcp: FastMCP) -> None:
         offset: Annotated[float, Field(default=0.0, ge=0.0)] = 0.0,
         ordering: str = "",
     ) -> Any:
-        """n8n-compat wrapper. Parses strings to native types, calls impl."""
+        """n8n-compat wrapper for netbox_get_objects. See description for details."""
         return _netbox_get_objects_impl(
             object_type=object_type,
             filters=_parse_filters(filters),
@@ -738,14 +707,14 @@ def _register_compat_tools(mcp: FastMCP) -> None:
             ordering=ordering,
         )
 
-    @mcp.tool()
+    @mcp.tool(description=_compat_description(_NETBOX_GET_OBJECT_BY_ID_DESCRIPTION))
     def netbox_get_object_by_id(
         object_type: str,
         object_id: float,
         fields: str = "",
         brief: bool = False,
     ) -> Any:
-        """n8n-compat wrapper for netbox_get_object_by_id."""
+        """n8n-compat wrapper for netbox_get_object_by_id. See description for details."""
         return _netbox_get_object_by_id_impl(
             object_type=object_type,
             object_id=int(object_id),
@@ -753,19 +722,19 @@ def _register_compat_tools(mcp: FastMCP) -> None:
             brief=brief,
         )
 
-    @mcp.tool(description=_NETBOX_GET_CHANGELOGS_DESCRIPTION)
+    @mcp.tool(description=_compat_description(_NETBOX_GET_CHANGELOGS_DESCRIPTION))
     def netbox_get_changelogs(filters: str = "{}") -> Any:
-        """n8n-compat wrapper for netbox_get_changelogs."""
+        """n8n-compat wrapper for netbox_get_changelogs. See description for details."""
         return _netbox_get_changelogs_impl(_parse_filters(filters))
 
-    @mcp.tool(description=_NETBOX_SEARCH_OBJECTS_DESCRIPTION)
+    @mcp.tool(description=_compat_description(_NETBOX_SEARCH_OBJECTS_DESCRIPTION))
     def netbox_search_objects(
         query: str,
         object_types: str = "",
         fields: str = "",
         limit: Annotated[float, Field(default=5.0, ge=1.0, le=100.0)] = 5.0,
     ) -> dict[str, list[dict[str, Any]]]:
-        """n8n-compat wrapper for netbox_search_objects."""
+        """n8n-compat wrapper for netbox_search_objects. See description for details."""
         return _netbox_search_objects_impl(
             query=query,
             object_types=_parse_list_param(object_types),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,3 +116,82 @@ def test_configure_logging_shows_http_clients_at_debug():
     assert root_logger.level == logging.DEBUG
     assert urllib3_logger.level == logging.DEBUG
     assert httpx_logger.level == logging.DEBUG
+
+
+# ===== n8n Compatibility Flag Tests =====
+
+
+def test_settings_n8n_compat_defaults_false():
+    """Default value of n8n_compat is False (opt-in only)."""
+    settings = Settings(
+        netbox_url="https://netbox.example.com/",
+        netbox_token="test-token",
+        _env_file=None,
+    )
+    assert settings.n8n_compat is False
+
+
+def test_settings_n8n_compat_from_env():
+    """NETBOX_MCP_N8N_COMPAT=true env var enables compat mode."""
+    with patch.dict(
+        "os.environ",
+        {
+            "NETBOX_URL": "https://netbox.example.com/",
+            "NETBOX_TOKEN": "test-token",
+            "NETBOX_MCP_N8N_COMPAT": "true",
+        },
+        clear=True,
+    ):
+        settings = Settings(_env_file=None)
+        assert settings.n8n_compat is True
+
+
+def test_settings_n8n_compat_not_set_by_bare_env_var():
+    """Bare N8N_COMPAT env var is NOT recognised — only the prefixed form.
+
+    We intentionally do not accept a bare-name alias to avoid namespace
+    collisions in multi-service deploys.
+    """
+    with patch.dict(
+        "os.environ",
+        {
+            "NETBOX_URL": "https://netbox.example.com/",
+            "NETBOX_TOKEN": "test-token",
+            "N8N_COMPAT": "true",
+        },
+        clear=True,
+    ):
+        settings = Settings(_env_file=None)
+        assert settings.n8n_compat is False
+
+
+def test_settings_n8n_compat_appears_in_summary():
+    """get_effective_config_summary includes n8n_compat so it's logged at startup."""
+    settings = Settings(
+        netbox_url="https://netbox.example.com/",
+        netbox_token="test-token",
+        n8n_compat=True,
+    )
+    assert settings.get_effective_config_summary()["n8n_compat"] is True
+
+
+def test_parse_cli_args_n8n_compat_flag():
+    """--n8n-compat CLI flag is captured in the overlay."""
+    original_argv = sys.argv
+    try:
+        sys.argv = ["server.py", "--n8n-compat"]
+        result = parse_cli_args()
+        assert result["n8n_compat"] is True
+    finally:
+        sys.argv = original_argv
+
+
+def test_parse_cli_args_n8n_compat_default_absent():
+    """Without --n8n-compat, the key is absent from the overlay."""
+    original_argv = sys.argv
+    try:
+        sys.argv = ["server.py"]
+        result = parse_cli_args()
+        assert "n8n_compat" not in result
+    finally:
+        sys.argv = original_argv

--- a/tests/test_impl_parity.py
+++ b/tests/test_impl_parity.py
@@ -1,0 +1,121 @@
+"""Parity test: strict and compat wrappers must produce identical NetBox API calls.
+
+The impl function is shared, so the real risk surface is the compat wrapper's
+string-parsing step. Cases here exercise only inputs that are actually
+transformed (JSON <-> dict, CSV <-> list). Trivially equivalent numeric casts
+(limit=10 vs 10.0) are covered by unit tests elsewhere.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from fastmcp import Client
+
+from netbox_mcp_server.server import create_mcp
+
+EMPTY_RESPONSE = {"count": 0, "next": None, "previous": None, "results": []}
+
+
+async def _call(mcp, tool_name: str, arguments: dict):
+    async with Client(mcp) as client:
+        return await client.call_tool(tool_name, arguments)
+
+
+@pytest.mark.parametrize(
+    ("strict_kwargs", "compat_kwargs"),
+    [
+        # filters: dict <-> JSON string
+        (
+            {"object_type": "dcim.site", "filters": {"status": "active"}},
+            {"object_type": "dcim.site", "filters": '{"status": "active"}'},
+        ),
+        (
+            {"object_type": "dcim.site", "filters": {"name__ic": "router", "id__in": [1, 2, 3]}},
+            {"object_type": "dcim.site", "filters": '{"name__ic": "router", "id__in": [1, 2, 3]}'},
+        ),
+        # fields: list <-> CSV string
+        (
+            {"object_type": "dcim.site", "filters": {}, "fields": ["id", "name"]},
+            {"object_type": "dcim.site", "filters": "{}", "fields": "id,name"},
+        ),
+        # n8n-style empty filter string: "null" in compat = {} in strict
+        (
+            {"object_type": "dcim.site", "filters": {}},
+            {"object_type": "dcim.site", "filters": "null"},
+        ),
+    ],
+)
+def test_get_objects_parity(strict_kwargs, compat_kwargs):
+    """Semantically equivalent inputs to both modes produce identical API params."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+
+        strict_mcp = create_mcp(n8n_compat=False)
+        asyncio.run(_call(strict_mcp, "netbox_get_objects", strict_kwargs))
+        strict_params = mock.get.call_args[1]["params"]
+
+        mock.reset_mock()
+        mock.get.return_value = EMPTY_RESPONSE
+
+        compat_mcp = create_mcp(n8n_compat=True)
+        asyncio.run(_call(compat_mcp, "netbox_get_objects", compat_kwargs))
+        compat_params = mock.get.call_args[1]["params"]
+
+    assert strict_params == compat_params, (
+        f"Mode divergence!\nstrict: {strict_params}\ncompat: {compat_params}"
+    )
+
+
+def test_search_objects_parity():
+    """Search tool: list[str] in strict <-> CSV in compat.
+
+    Asserts both modes searched the same number of object types (guards
+    against _parse_list_param silently dropping a type) and that the
+    outgoing API params are identical.
+    """
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+
+        strict_mcp = create_mcp(n8n_compat=False)
+        asyncio.run(
+            _call(
+                strict_mcp,
+                "netbox_search_objects",
+                {
+                    "query": "nyc",
+                    "object_types": ["dcim.site", "dcim.device"],
+                    "fields": ["id", "name"],
+                },
+            )
+        )
+        strict_call_count = mock.get.call_count
+        # Capture params from the last call; they're structurally identical per-type
+        # because _netbox_search_objects_impl builds the same {q, limit, fields} dict.
+        strict_params = mock.get.call_args[1]["params"]
+
+        mock.reset_mock()
+        mock.get.return_value = EMPTY_RESPONSE
+
+        compat_mcp = create_mcp(n8n_compat=True)
+        asyncio.run(
+            _call(
+                compat_mcp,
+                "netbox_search_objects",
+                {
+                    "query": "nyc",
+                    "object_types": "dcim.site,dcim.device",
+                    "fields": "id,name",
+                },
+            )
+        )
+        compat_call_count = mock.get.call_count
+        compat_params = mock.get.call_args[1]["params"]
+
+    assert strict_call_count == compat_call_count, (
+        f"Mode divergence in searched types!\n"
+        f"strict searched {strict_call_count} types; compat searched {compat_call_count}"
+    )
+    assert strict_params == compat_params, (
+        f"Mode divergence in API params!\nstrict: {strict_params}\ncompat: {compat_params}"
+    )

--- a/tests/test_mcp_boundary.py
+++ b/tests/test_mcp_boundary.py
@@ -1,0 +1,157 @@
+"""End-to-end tests through the FastMCP schema-validation boundary.
+
+Most other tests invoke the strict-mode wrappers directly (``tool_fn(...)``),
+bypassing Pydantic's schema enforcement. The tests in this file go through
+``Client.call_tool``, which is the path every real MCP client takes — the
+schema is enforced.
+
+Both modes are exercised: the compat-mode tests verify n8n's string-typed
+schema still works when ``n8n_compat=True``, and the strict-mode tests
+(default) verify that LLM clients can use native JSON types.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from fastmcp import Client
+
+from netbox_mcp_server.server import create_mcp
+
+EMPTY_RESPONSE = {"count": 0, "next": None, "previous": None, "results": []}
+
+
+async def _call_compat(tool_name: str, arguments: dict):
+    mcp = create_mcp(n8n_compat=True)
+    async with Client(mcp) as client:
+        return await client.call_tool(tool_name, arguments)
+
+
+async def _call_strict(tool_name: str, arguments: dict):
+    mcp = create_mcp(n8n_compat=False)
+    async with Client(mcp) as client:
+        return await client.call_tool(tool_name, arguments)
+
+
+def test_string_filters_accepted_through_mcp_boundary():
+    """JSON-string filters — the shape n8n and LLM clients send — must round-trip."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+        asyncio.run(
+            _call_compat(
+                "netbox_get_objects",
+                {"object_type": "dcim.site", "filters": '{"status": "active"}'},
+            )
+        )
+        params = mock.get.call_args[1]["params"]
+        assert params["status"] == "active"
+
+
+def test_dict_filters_rejected_through_mcp_boundary():
+    """Native dicts must be rejected at the boundary.
+
+    Regression guard: if a future refactor widens the schema to accept `object`,
+    n8n's `mapTypes` will fail again. See #58 and n8n-io/n8n#19835.
+    """
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+        with pytest.raises(Exception, match="valid string"):
+            asyncio.run(
+                _call_compat(
+                    "netbox_get_objects",
+                    {"object_type": "dcim.site", "filters": {"status": "active"}},
+                )
+            )
+
+
+def test_integer_limit_accepted_and_coerced():
+    """LLM clients sending integer `limit` must still work.
+
+    JSON Schema `number` (our n8n-compatible annotation) accepts integers,
+    and Pydantic coerces them to float before the int(limit) conversion
+    inside the function body.
+    """
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+        asyncio.run(
+            _call_compat(
+                "netbox_get_objects",
+                {"object_type": "dcim.site", "limit": 10},
+            )
+        )
+        assert mock.get.call_args[1]["params"]["limit"] == 10
+
+
+def test_integer_object_id_accepted_through_mcp_boundary():
+    """Native integer IDs (how LLM clients reference objects) must pass schema validation."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = {"id": 42, "name": "site-nyc"}
+        asyncio.run(
+            _call_compat(
+                "netbox_get_object_by_id",
+                {"object_type": "dcim.site", "object_id": 42},
+            )
+        )
+        called_endpoint = mock.get.call_args[0][0]
+        assert called_endpoint.endswith("/42")
+
+
+# ===== Strict-mode (default) boundary tests =====
+
+
+def test_strict_dict_filters_accepted_through_mcp_boundary():
+    """Strict mode: clients may send native JSON objects as filters."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+        asyncio.run(
+            _call_strict(
+                "netbox_get_objects",
+                {"object_type": "dcim.site", "filters": {"status": "active"}},
+            )
+        )
+        params = mock.get.call_args[1]["params"]
+        assert params["status"] == "active"
+
+
+def test_strict_list_fields_accepted_through_mcp_boundary():
+    """Strict mode: clients may send native arrays for fields."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+        asyncio.run(
+            _call_strict(
+                "netbox_get_objects",
+                {
+                    "object_type": "dcim.site",
+                    "filters": {},
+                    "fields": ["id", "name"],
+                },
+            )
+        )
+        params = mock.get.call_args[1]["params"]
+        assert params["fields"] == "id,name"
+
+
+def test_strict_integer_limit_accepted():
+    """Strict mode: clients may send native integers for limit."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+        asyncio.run(
+            _call_strict(
+                "netbox_get_objects",
+                {"object_type": "dcim.site", "filters": {}, "limit": 10},
+            )
+        )
+        assert mock.get.call_args[1]["params"]["limit"] == 10
+
+
+def test_strict_string_filters_rejected_through_mcp_boundary():
+    """Strict mode: passing a JSON string as filters is rejected at the schema boundary."""
+    with patch("netbox_mcp_server.server.netbox") as mock:
+        mock.get.return_value = EMPTY_RESPONSE
+        with pytest.raises(Exception, match=r"valid dictionary"):
+            asyncio.run(
+                _call_strict(
+                    "netbox_get_objects",
+                    {"object_type": "dcim.site", "filters": '{"status": "active"}'},
+                )
+            )

--- a/tests/test_mcp_boundary.py
+++ b/tests/test_mcp_boundary.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 import pytest
 from fastmcp import Client
+from fastmcp.exceptions import ToolError
 
 from netbox_mcp_server.server import create_mcp
 
@@ -55,7 +56,7 @@ def test_dict_filters_rejected_through_mcp_boundary():
     """
     with patch("netbox_mcp_server.server.netbox") as mock:
         mock.get.return_value = EMPTY_RESPONSE
-        with pytest.raises(Exception, match="valid string"):
+        with pytest.raises(ToolError, match=r"type=string_type"):
             asyncio.run(
                 _call_compat(
                     "netbox_get_objects",
@@ -148,7 +149,7 @@ def test_strict_string_filters_rejected_through_mcp_boundary():
     """Strict mode: passing a JSON string as filters is rejected at the schema boundary."""
     with patch("netbox_mcp_server.server.netbox") as mock:
         mock.get.return_value = EMPTY_RESPONSE
-        with pytest.raises(Exception, match=r"valid dictionary"):
+        with pytest.raises(ToolError, match=r"type=dict_type"):
             asyncio.run(
                 _call_strict(
                     "netbox_get_objects",

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -9,7 +9,7 @@ from netbox_mcp_server.server import netbox_get_objects
 
 
 def test_ordering_rejects_invalid_types():
-    """Ordering parameter should reject non-string/non-list types."""
+    """Ordering parameter should reject non-string types but accept strings."""
     ordering_annotation = netbox_get_objects.__annotations__["ordering"]
     adapter = TypeAdapter(ordering_annotation)
 
@@ -19,13 +19,13 @@ def test_ordering_rejects_invalid_types():
     with pytest.raises(ValidationError):
         adapter.validate_python({"field": "name"})
 
-    with pytest.raises(ValidationError):
-        adapter.validate_python(["name", 123])
+    # Plain strings accepted (multiple fields via comma-separated form)
+    assert adapter.validate_python("name,-id") == "name,-id"
 
 
 @patch("netbox_mcp_server.server.netbox")
-def test_ordering_none_omits_parameter(mock_netbox):
-    """When ordering=None, should not include ordering in API params."""
+def test_ordering_default_omits_parameter(mock_netbox):
+    """When ordering is not specified (default empty string), should not include ordering in API params."""
     mock_netbox.get.return_value = {
         "count": 0,
         "results": [],
@@ -33,12 +33,12 @@ def test_ordering_none_omits_parameter(mock_netbox):
         "previous": None,
     }
 
-    netbox_get_objects(object_type="dcim.site", filters={}, ordering=None)
+    netbox_get_objects(object_type="dcim.site", filters={})
 
     call_args = mock_netbox.get.call_args
     params = call_args[1]["params"]
 
-    # ordering should not be in params when None
+    # ordering should not be in params when using default empty string
     assert "ordering" not in params
 
 
@@ -98,8 +98,30 @@ def test_ordering_single_field_descending(mock_netbox):
 
 
 @patch("netbox_mcp_server.server.netbox")
-def test_ordering_multiple_fields_as_list(mock_netbox):
-    """When ordering=['facility', '-name'], should pass comma-separated string."""
+def test_ordering_multiple_fields_comma_separated(mock_netbox):
+    """When ordering='facility,-name', should pass comma-separated string to API."""
+    mock_netbox.get.return_value = {
+        "count": 0,
+        "results": [],
+        "next": None,
+        "previous": None,
+    }
+
+    netbox_get_objects(object_type="dcim.site", filters={}, ordering="facility,-name")
+
+    call_args = mock_netbox.get.call_args
+    params = call_args[1]["params"]
+
+    # Comma-separated string should be passed as-is
+    assert params["ordering"] == "facility,-name"
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_ordering_list_joined_comma_separated(mock_netbox):
+    """List of strings should be joined with commas before being sent to the API.
+
+    Restores the pre-#61 contract: callers may pass ordering as a list.
+    """
     mock_netbox.get.return_value = {
         "count": 0,
         "results": [],
@@ -109,16 +131,13 @@ def test_ordering_multiple_fields_as_list(mock_netbox):
 
     netbox_get_objects(object_type="dcim.site", filters={}, ordering=["facility", "-name"])
 
-    call_args = mock_netbox.get.call_args
-    params = call_args[1]["params"]
-
-    # List should be converted to comma-separated string
+    params = mock_netbox.get.call_args[1]["params"]
     assert params["ordering"] == "facility,-name"
 
 
 @patch("netbox_mcp_server.server.netbox")
-def test_ordering_empty_list_omits_parameter(mock_netbox):
-    """When ordering=[], should not include ordering in API params."""
+def test_ordering_whitespace_only_omits_parameter(mock_netbox):
+    """When ordering contains only whitespace, should not include ordering in API params."""
     mock_netbox.get.return_value = {
         "count": 0,
         "results": [],
@@ -126,10 +145,10 @@ def test_ordering_empty_list_omits_parameter(mock_netbox):
         "previous": None,
     }
 
-    netbox_get_objects(object_type="dcim.site", filters={}, ordering=[])
+    netbox_get_objects(object_type="dcim.site", filters={}, ordering="   ")
 
     call_args = mock_netbox.get.call_args
     params = call_args[1]["params"]
 
-    # Empty list should result in empty string, which should be omitted
+    # Whitespace-only string should be omitted
     assert "ordering" not in params

--- a/tests/test_param_parsing.py
+++ b/tests/test_param_parsing.py
@@ -1,0 +1,68 @@
+"""Tests for parameter parsing helper functions."""
+
+import pytest
+
+from netbox_mcp_server.server import _parse_filters, _parse_list_param
+
+
+class TestParseFilters:
+    """Tests for _parse_filters function."""
+
+    def test_returns_dict_unchanged(self):
+        """Should return dict unchanged."""
+        filters = {"status": "active", "site_id": 1}
+        assert _parse_filters(filters) == filters
+
+    def test_parses_json_string(self):
+        """Should parse valid JSON string."""
+        assert _parse_filters('{"status": "active"}') == {"status": "active"}
+
+    def test_strips_whitespace_from_json(self):
+        """Should strip whitespace from JSON string before parsing."""
+        assert _parse_filters('  {"status": "active"}  ') == {"status": "active"}
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, "", "   ", "undefined", "UNDEFINED", "null", "NULL", "none", "None"],
+    )
+    def test_returns_empty_dict_for_empty_values(self, value):
+        """Should return empty dict for None, empty string, or n8n-style nulls."""
+        assert _parse_filters(value) == {}
+
+    def test_raises_on_invalid_json(self):
+        """Should raise ValueError for invalid JSON."""
+        with pytest.raises(ValueError, match="Invalid filters JSON"):
+            _parse_filters("not valid json")
+
+
+class TestParseListParam:
+    """Tests for _parse_list_param function."""
+
+    def test_returns_list_unchanged(self):
+        """Should return list unchanged."""
+        value = ["id", "name", "status"]
+        assert _parse_list_param(value) == value
+
+    def test_parses_comma_separated_string(self):
+        """Should parse comma-separated string into list."""
+        assert _parse_list_param("id,name,status") == ["id", "name", "status"]
+
+    def test_strips_whitespace_around_items(self):
+        """Should strip whitespace around items."""
+        assert _parse_list_param("id, name, status") == ["id", "name", "status"]
+
+    def test_filters_empty_items(self):
+        """Should filter out empty items from comma-separated string."""
+        assert _parse_list_param("id,,name,") == ["id", "name"]
+
+    def test_handles_single_item(self):
+        """Should handle single item without comma."""
+        assert _parse_list_param("id") == ["id"]
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, "", "   ", "undefined", "null"],
+    )
+    def test_returns_empty_list_for_empty_values(self, value):
+        """Should return empty list for None, empty string, or n8n-style nulls."""
+        assert _parse_list_param(value) == []

--- a/tests/test_param_parsing.py
+++ b/tests/test_param_parsing.py
@@ -34,6 +34,23 @@ class TestParseFilters:
         with pytest.raises(ValueError, match="Invalid filters JSON"):
             _parse_filters("not valid json")
 
+    @pytest.mark.parametrize(
+        "value",
+        ['"hello"', "42", "3.14", "true", "[1, 2, 3]"],
+    )
+    def test_rejects_non_dict_json(self, value):
+        """Should raise ValueError when parsed JSON is valid but not a dict.
+
+        Regression guard: json.loads('"hello"') returns the string "hello",
+        which is valid JSON but would crash the impl's filters.copy() call.
+        The error surfaces the mismatch at the boundary instead.
+
+        Note: 'null' is handled upstream via _is_empty_string → {} before
+        json.loads runs, so it isn't part of this parameter set.
+        """
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            _parse_filters(value)
+
 
 class TestParseListParam:
     """Tests for _parse_list_param function."""

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -32,9 +32,9 @@ async def _get_filters_types(n8n_compat: bool) -> set[str]:
 
 
 def test_strict_mode_advertises_object_filters():
-    """Default mode advertises filters as JSON object (nullable). No strings allowed."""
+    """Default mode advertises filters as a required JSON object. No strings or null allowed."""
     types = asyncio.run(_get_filters_types(n8n_compat=False))
-    assert types == {"object", "null"}
+    assert types == {"object"}
 
 
 def test_compat_mode_advertises_string_filters():

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -1,0 +1,43 @@
+"""Sanity checks that the flag flips the advertised tool schema.
+
+We deliberately do not exhaustively assert every property's type — that would
+test FastMCP's schema generation, not our code. One assertion per mode on the
+key type difference is enough.
+"""
+
+import asyncio
+
+from fastmcp import Client
+
+from netbox_mcp_server.server import create_mcp
+
+
+async def _get_filters_types(n8n_compat: bool) -> set[str]:
+    """Return the set of types accepted by the ``filters`` parameter schema.
+
+    Pydantic renders ``dict | None = None`` as ``anyOf: [{type: object}, {type: null}]``,
+    and ``str = "{}"`` as a single ``{type: string}``. Normalising to a set
+    lets each test assert the exact accepted type universe.
+    """
+    mcp = create_mcp(n8n_compat=n8n_compat)
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+        for tool in tools:
+            if tool.name == "netbox_get_objects":
+                schema = tool.inputSchema["properties"]["filters"]
+                if "anyOf" in schema:
+                    return {entry.get("type") for entry in schema["anyOf"]}
+                return {schema.get("type")}
+    raise AssertionError("netbox_get_objects not found in registered tools")
+
+
+def test_strict_mode_advertises_object_filters():
+    """Default mode advertises filters as JSON object (nullable). No strings allowed."""
+    types = asyncio.run(_get_filters_types(n8n_compat=False))
+    assert types == {"object", "null"}
+
+
+def test_compat_mode_advertises_string_filters():
+    """Compat mode advertises filters as a string only. No objects allowed."""
+    types = asyncio.run(_get_filters_types(n8n_compat=True))
+    assert types == {"string"}

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -41,3 +41,47 @@ def test_compat_mode_advertises_string_filters():
     """Compat mode advertises filters as a string only. No objects allowed."""
     types = asyncio.run(_get_filters_types(n8n_compat=True))
     assert types == {"string"}
+
+
+async def _get_tool_description(tool_name: str, n8n_compat: bool) -> str:
+    """Return the ``description`` field of a registered tool as seen by MCP clients."""
+    mcp = create_mcp(n8n_compat=n8n_compat)
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+        for tool in tools:
+            if tool.name == tool_name:
+                return tool.description or ""
+    raise AssertionError(f"{tool_name} not found in registered tools")
+
+
+def test_compat_mode_description_has_preamble():
+    """Compat-mode descriptions warn LLMs about JSON-string / CSV parameter shapes."""
+    for tool_name in (
+        "netbox_get_objects",
+        "netbox_get_object_by_id",
+        "netbox_get_changelogs",
+        "netbox_search_objects",
+    ):
+        desc = asyncio.run(_get_tool_description(tool_name, n8n_compat=True))
+        assert "JSON STRING" in desc, f"{tool_name} missing JSON-string guidance"
+        assert "COMMA-SEPARATED" in desc, f"{tool_name} missing CSV guidance"
+
+
+def test_strict_mode_description_has_no_preamble():
+    """Strict-mode descriptions must not carry the compat preamble (cosmetic noise for strict clients)."""
+    for tool_name in (
+        "netbox_get_objects",
+        "netbox_get_object_by_id",
+        "netbox_get_changelogs",
+        "netbox_search_objects",
+    ):
+        desc = asyncio.run(_get_tool_description(tool_name, n8n_compat=False))
+        assert "JSON STRING" not in desc, f"{tool_name} leaked compat preamble"
+        assert "COMMA-SEPARATED" not in desc, f"{tool_name} leaked compat preamble"
+
+
+def test_compat_get_object_by_id_has_rich_description():
+    """Regression guard for C1: compat's get_object_by_id previously served only a 47-char stub."""
+    desc = asyncio.run(_get_tool_description("netbox_get_object_by_id", n8n_compat=True))
+    assert "Field filtering reduces response payload" in desc
+    assert len(desc) > 500


### PR DESCRIPTION
## Summary

Adds an **opt-in** n8n compatibility mode for users connecting this server from n8n's AI Agent MCP client. Default behavior is unchanged — clients see native JSON Schema types (`integer`/`array`/`object`). Setting `NETBOX_MCP_N8N_COMPAT=true` (or `--n8n-compat`) switches the tool schemas to the string/number-only types n8n's `mapTypes` table requires.

## Why opt-in, not default

n8n's MCP client has a hardcoded type-mapping table that does not support `integer`, `array`, or `object` parameter types — only `string`, `number`, `boolean`, and `json`. Applying that constraint globally (as PR #61 did) degraded the schema for every other client. Reverting #61 (done via #121) gated n8n users entirely on the upstream fix shipping.

This PR restores n8n support as a narrow opt-in, so n8n users can work while upstream lands a fix, without penalizing clients that handle native types correctly (Claude, Cursor, Cline, etc.).

## Architecture

Three layers:

- **`_netbox_*_impl` functions** — shared business logic, take native types
- **Strict-mode wrappers** (module-level, default) — native `int`/`list`/`dict`
- **Compat-mode closures** (inside `_register_compat_tools`) — string/float forms n8n understands, parse and delegate to the impls
- **`create_mcp(n8n_compat: bool) -> FastMCP`** factory picks the registrar at startup based on settings

Both wrappers delegate to the same `_impl` functions; the new `test_impl_parity.py` asserts they produce identical outgoing NetBox API params for semantically equivalent inputs.

## Test plan

- [x] `uv run pytest -q` — **111 passed** (72 baseline + 39 new)
- [x] `test_tool_registration.py` — asserts filters schema flips between `{object, null}` (strict) and `{string}` (compat)
- [x] `test_impl_parity.py` — parameterized regression guard: identical API params across modes for equivalent inputs (including n8n-style `"null"` empty strings and `object_types` list-vs-CSV)
- [x] `test_mcp_boundary.py` — end-to-end via FastMCP schema validation for both modes
- [x] `test_param_parsing.py` — unit tests for the compat-mode string parsers
- [x] ruff check + ruff format — clean
- [ ] Manual verification with Claude Desktop (default strict mode) — native types render cleanly
- [ ] Manual verification with n8n AI Agent (compat mode) — string types accepted

## Upstream tracking

n8n#20682 proposes the fix but has been unreviewed since Oct 2025. This flag will be removed once that fix (or equivalent) ships in an n8n release.
Related issues: n8n-io/n8n#19835, n8n-io/n8n#21569.

## Commits

1. `feat(config): add n8n_compat setting and --n8n-compat CLI flag` — Pydantic field + CLI flag + config tests. No consumer yet.
2. `feat(server): add opt-in n8n compatibility mode via create_mcp factory` — introduces the factory + registrars + parsing helpers + tests. This is the substantive commit.
3. `docs: document --n8n-compat flag in README` — Configuration subsection + table row.