### PR TITLE
docs: add CONTRIBUTING.md and clarify project scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 A read-only [Model Context Protocol](https://modelcontextprotocol.io/) server that enables LLMs to interact with NetBox infrastructure data. Built with FastMCP and designed for use by NetBox operators.
 
-**Your role**: Help contributors design and implement features following open-source best practices. Ask clarifying questions and challenge assumptions when needed.
+**Your role**: Help contributors design and implement features within the project's stated scope (see [CONTRIBUTING.md](CONTRIBUTING.md)). Challenge proposals that fall outside scope before implementation begins, not after. Ask clarifying questions and challenge assumptions when needed.
 
 ## Tech Stack
 
@@ -373,4 +373,5 @@ mcp_tool("netbox_get_changelogs", {
 - [Model Context Protocol Specification](https://modelcontextprotocol.io/)
 - [FastMCP Documentation](https://github.com/jlowin/fastmcp)
 - [Project README](./README.md) - User-facing setup and usage
+- [Contributing Guide](./CONTRIBUTING.md) - Project scope, contribution workflow, and out-of-scope list
 - [Security Policy](./SECURITY.md) - Vulnerability reporting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to NetBox MCP Server
+
+Thanks for your interest in contributing! This guide covers what kinds of contributions we're looking for, how to propose them, and where the project's boundaries are.
+
+Questions that don't need a code change are best asked in the `#ai` channel on [NetDev Community Slack](https://netdev.chat/) - this project doesn't have dedicated community channels yet.
+
+## Project scope
+
+The NetBox MCP Server is a **simple, read-only MCP server for core NetBox objects**. It uses the NetBox REST API with static token authentication. The priorities are:
+
+- **Easy to get started.** Minimal configuration, minimal dependencies, runs locally in under a minute.
+- **Hard to misuse.** Read-only by design, no plugin surface, small attack surface.
+- **Easy to fork.** Apache 2.0 licensed, small codebase, designed to be adapted.
+
+This project is maintained by a small team - scope is deliberately limited so it stays that way. We may decline feature proposals that fall outside the areas listed below, even if they're well-executed.
+
+### Forking is a first-class option
+
+If your use case needs features outside this scope, forking is actively encouraged. The project is small and focused by design - your fork can diverge without losing the core. We welcome issues or discussions that share interesting forks back with the community.
+
+## Reporting bugs
+
+Bug reports should describe unintended or unexpected behaviour - not requests for new functionality (see "Feature requests" below for that).
+
+1. Check you're running the [latest release](https://github.com/netboxlabs/netbox-mcp-server/releases) - your bug may already be fixed.
+2. Search [existing issues](https://github.com/netboxlabs/netbox-mcp-server/issues) to see if it's been reported. If so, add a 👍 reaction and any extra context as a comment.
+3. If it's new, [open an issue](https://github.com/netboxlabs/netbox-mcp-server/issues/new) with clear reproduction steps, error messages, and NetBox/Python versions.
+
+Tips:
+
+- Screenshots and exact error messages are especially helpful.
+- Don't prepend your issue title with a label like `[Bug]` - labels are applied by maintainers.
+
+## Feature requests
+
+Before opening a feature request:
+
+1. **Check the scope section above.** If your idea falls outside the project's scope, please consider a fork rather than an FR.
+2. **Search existing issues** to avoid duplicates.
+3. **Open an issue for discussion first.** Don't start implementation until a maintainer has confirmed scope fit.
+
+In-scope contributions we're especially keen to see:
+
+- Bug fixes in existing tools
+- Improvements to error messages and logging
+- Documentation, examples, and quickstart improvements
+- Adding new core NetBox object types to `src/netbox_mcp_server/netbox_types.py`
+- Compatibility fixes for new NetBox versions
+- Dependency updates
+
+## Submitting pull requests
+
+For non-trivial changes, please **open an issue first**. This saves you time - if the change isn't a good fit, we can tell you before you write the code. Drive-by bug fixes and small docs improvements don't need an issue first - just send a PR.
+
+Our process for larger changes:
+
+1. Open an issue describing the bug or feature.
+2. Wait for maintainer response confirming scope and approach.
+3. Submit a PR referencing the issue.
+4. Respond to review feedback.
+5. Maintainer merges.
+
+PR checklist:
+
+- Base off `main`.
+- Conventional commit format (`feat:`, `fix:`, `chore:`, etc. - see [`CLAUDE.md`](CLAUDE.md) for details).
+- `ruff check` passes.
+- Type hints on all public functions.
+
+Detailed code standards live in [`CLAUDE.md`](CLAUDE.md) - please skim it before your first PR.
+
+## AI-assisted contributions
+
+AI-assisted contributions are welcome. We use AI tools ourselves. That said, you're responsible for what you submit - review it, test it, and take ownership. PRs that appear to be unreviewed AI output will be asked for revision or closed.
+
+## Other ways to contribute
+
+Not every useful contribution is code:
+
+- Answering questions in discussions or issues
+- Writing a blog post or video about your use case
+- Sharing useful forks back via issues or discussions
+- Improving documentation

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 > - Docker users: rebuild images with updated CMD
 > - See [CHANGELOG.md](CHANGELOG.md) for full details
 
-This is a simple read-only [Model Context Protocol](https://modelcontextprotocol.io/) server for NetBox.  It enables you to interact with your data in NetBox directly via LLMs that support MCP.
+This is a simple read-only [Model Context Protocol](https://modelcontextprotocol.io/) server for NetBox. It enables you to interact with your data in NetBox directly via LLMs that support MCP.
+
+The server is intentionally simple — easy to get started with, hard to misuse (read-only by default, no plugin surface), and easy to fork and adapt. Forking under Apache 2.0 is a first-class path for users who need capabilities beyond the project's scope.
 
 ## Tools
 
@@ -17,7 +19,7 @@ This is a simple read-only [Model Context Protocol](https://modelcontextprotocol
 | get_object_by_id | Gets detailed information about a specific NetBox object by its ID |
 | get_changelogs | Retrieves change history records (audit trail) based on filters |
 
-> Note: the set of supported object types is explicitly defined and limited to the core NetBox objects for now, and won't work with object types from plugins.
+> Note: The set of supported object types is explicitly limited to core NetBox objects. Plugin object types and advanced features (GraphQL, dynamic model discovery, etc.) are deliberately out of scope — see [CONTRIBUTING.md](CONTRIBUTING.md) for the full scope statement and rationale.
 
 ## Usage
 
@@ -310,7 +312,9 @@ The server will be accessible at `http://localhost:8000/mcp` for MCP clients. Yo
 
 ## Development
 
-Contributions are welcome!  Please open an issue or submit a PR.
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing new features — we encourage filing an issue for discussion first to confirm scope fit.
+
+If your use case needs capabilities outside this project's scope, forking under Apache 2.0 is an actively supported path.
 
 ## License
 


### PR DESCRIPTION
- Add CONTRIBUTING.md stating what's in/out of scope, discuss-first workflow expectations, and forking as a first-class path for use cases outside the server's intended scope.
- Rename claude.md -> CLAUDE.md to match Claude Code convention and fix a latent case-sensitivity issue on non-macOS filesystems. Strengthen the "Your role" line and add a CONTRIBUTING.md reference.
- Update README: remove "for now" from the object-types note (scope is deliberate, not a temporary limitation), state the "simple and forkable" intent in the opening paragraph, and point contributors to CONTRIBUTING.md.