### PR TITLE
feat: add CORS_ORIGINS setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ PORT=8000
 # ===== Security Settings =====
 # Set to false only for testing with self-signed certificates
 VERIFY_SSL=true
+CORS_ORIGINS='["http://localhost:6274"]'
 
 # ===== Logging Configuration =====
 # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL

--- a/src/netbox_mcp_server/config.py
+++ b/src/netbox_mcp_server/config.py
@@ -95,7 +95,9 @@ class Settings(BaseSettings):
                 continue
             parsed = urlparse(origin)
             if not parsed.scheme or not parsed.netloc:
-                raise ValueError(f"Invalid CORS_ORIGIN: {origin!r} (expected format: http://host:port)")
+                raise ValueError(
+                    f"Invalid CORS_ORIGIN: {origin!r} (expected format: http://host:port)"
+                )
         return v
 
     def get_effective_config_summary(self) -> dict:
@@ -114,11 +116,13 @@ class Settings(BaseSettings):
             "log_level": self.log_level,
         }
         if self.transport == "http":
-            summary.update({
-                "host": self.host,
-                "port": self.port,
-                "cors_origins": self.cors_origins,
-            })
+            summary.update(
+                {
+                    "host": self.host,
+                    "port": self.port,
+                    "cors_origins": self.cors_origins,
+                }
+            )
         return summary
 
 

--- a/src/netbox_mcp_server/config.py
+++ b/src/netbox_mcp_server/config.py
@@ -3,8 +3,9 @@
 import logging
 import logging.config
 from typing import Any, Literal
+from urllib.parse import urlparse
 
-from pydantic import AnyUrl, SecretStr, field_validator, model_validator
+from pydantic import AnyUrl, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -33,6 +34,11 @@ class Settings(BaseSettings):
 
     port: int = 8000
     """Port to bind HTTP server (only used when transport='http')"""
+
+    cors_origins: list[str] = Field(
+        default_factory=list,
+        description="Browser origins allowed for HTTP CORS. Use * to allow any origin.",
+    )
 
     # ===== Plugin Discovery Settings =====
     enable_plugin_discovery: bool = False
@@ -80,6 +86,18 @@ class Settings(BaseSettings):
         """No additional validation needed for HTTP transport; defaults are appropriate."""
         return self
 
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def validate_cors_origins(cls, v: object) -> list[str]:
+        """Ensure each CORS origin is a valid URL."""
+        for origin in v:
+            if origin == "*":
+                continue
+            parsed = urlparse(origin)
+            if not parsed.scheme or not parsed.netloc:
+                raise ValueError(f"Invalid CORS_ORIGIN: {origin!r} (expected format: http://host:port)")
+        return v
+
     def get_effective_config_summary(self) -> dict:
         """
         Return a non-secret summary of effective configuration for logging.
@@ -87,16 +105,21 @@ class Settings(BaseSettings):
         Returns:
             Dictionary with configuration values (secrets masked)
         """
-        return {
+        summary: dict[str, Any] = {
             "netbox_url": str(self.netbox_url),
             "netbox_token": "***REDACTED***",
             "transport": self.transport,
-            "host": self.host if self.transport == "http" else "N/A",
-            "port": self.port if self.transport == "http" else "N/A",
             "verify_ssl": self.verify_ssl,
             "enable_plugin_discovery": self.enable_plugin_discovery,
             "log_level": self.log_level,
         }
+        if self.transport == "http":
+            summary.update({
+                "host": self.host,
+                "port": self.port,
+                "cors_origins": self.cors_origins,
+            })
+        return summary
 
 
 def configure_logging(

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -7,6 +7,8 @@ from typing import Annotated, Any
 import httpx
 from fastmcp import FastMCP
 from pydantic import Field
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
 
 from netbox_mcp_server.config import Settings, configure_logging
 from netbox_mcp_server.netbox_client import NetBoxRestClient
@@ -53,6 +55,11 @@ def parse_cli_args() -> dict[str, Any]:
         "--port",
         type=int,
         help="Port for HTTP server (default: 8000)",
+    )
+    parser.add_argument(
+        "--cors-origins",
+        action="append",
+        help='CORS origins (repeat flag). Use * to allow any origin (default: none)',
     )
 
     # Security settings
@@ -101,6 +108,8 @@ def parse_cli_args() -> dict[str, Any]:
         overlay["host"] = args.host
     if args.port is not None:
         overlay["port"] = args.port
+    if args.cors_origins is not None:
+        overlay["cors_origins"] = args.cors_origins
     if args.verify_ssl is not None:
         overlay["verify_ssl"] = args.verify_ssl
     if args.enable_plugin_discovery is not None:
@@ -705,7 +714,20 @@ def main() -> None:
             mcp.run(transport="stdio")
         elif settings.transport == "http":
             logger.info(f"Starting HTTP transport on {settings.host}:{settings.port}")
-            mcp.run(transport="http", host=settings.host, port=settings.port)
+            middleware = [
+                Middleware(
+                    CORSMiddleware,
+                    allow_origins=settings.cors_origins,
+                    allow_methods=["GET", "OPTIONS"],
+                    allow_headers=[
+                        "Authorization",
+                        "mcp-protocol-version",
+                        "mcp-session-id",
+                    ],
+                    expose_headers=["mcp-session-id"],
+                )
+            ]
+            mcp.run(transport="http", host=settings.host, port=settings.port, middleware=middleware)
     except Exception as e:
         logger.error(f"Failed to start MCP server: {e}")
         sys.exit(1)

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -59,7 +59,7 @@ def parse_cli_args() -> dict[str, Any]:
     parser.add_argument(
         "--cors-origins",
         action="append",
-        help='CORS origins (repeat flag). Use * to allow any origin (default: none)',
+        help="CORS origins (repeat flag). Use * to allow any origin (default: none)",
     )
 
     # Security settings

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -718,7 +718,7 @@ def main() -> None:
                 Middleware(
                     CORSMiddleware,
                     allow_origins=settings.cors_origins,
-                    allow_methods=["GET", "OPTIONS"],
+                    allow_methods=["GET", "POST", "OPTIONS"],
                     allow_headers=[
                         "Authorization",
                         "mcp-protocol-version",


### PR DESCRIPTION
Allow specifying CORS allowed origins to support browser-based tools like MCP Inspector.