### PR TITLE
feat(writes): add opt-in create/update/delete tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,11 @@
 
 ## Core Concept
 
-A read-only [Model Context Protocol](https://modelcontextprotocol.io/) server that enables LLMs to interact with NetBox infrastructure data. Built with FastMCP and designed for use by NetBox operators.
+A [Model Context Protocol](https://modelcontextprotocol.io/) server that enables LLMs to interact with NetBox infrastructure data. Built with FastMCP and designed for use by NetBox operators.
 
-**Your role**: Help contributors design and implement features within the project's stated scope (see [CONTRIBUTING.md](CONTRIBUTING.md)). Challenge proposals that fall outside scope before implementation begins, not after. Ask clarifying questions and challenge assumptions when needed.
+**This is a fork of [netboxlabs/netbox-mcp-server](https://github.com/netboxlabs/netbox-mcp-server)** that adds opt-in write tools (create/update/delete) gated behind `ENABLE_WRITES=true`. Upstream is read-only by design; this fork extends that scope. Read-only behavior is preserved as the default — writes only register when explicitly enabled.
+
+**Your role**: Help with features that fit this fork's purpose — a read-by-default NetBox MCP server with opt-in writes. Upstream's `CONTRIBUTING.md` describes the upstream project's scope (read-only, no plugin surface); on this fork, write-tool work is in scope. Challenge proposals that don't fit *this* fork (e.g. plugin object types, GraphQL, removing the write gate). Ask clarifying questions when needed.
 
 ## Tech Stack
 
@@ -130,7 +132,7 @@ def get_stuff(t, f):
 ### Architecture Patterns
 
 - **Abstraction layer**: `NetBoxClientBase` defines interface for future ORM implementation
-- **Read-only by design**: Only GET operations exposed; no create/update/delete tools
+- **Read-only by default, opt-in writes**: GET tools are always registered. `create_object`/`update_object`/`delete_object` only register when `ENABLE_WRITES=true`; the gate lives in `_register_write_tools()` and is called from `main()`. `delete_object` additionally requires `confirm=True` and supports `dry_run=True`. Mutations are logged at INFO by the tool layer in addition to NetBox's changelog.
 - **Environment-based config**: All secrets via environment variables, never hardcoded
 - **Explicit object mapping**: `NETBOX_OBJECT_TYPES` dictionary maintains allowed types
 
@@ -167,12 +169,13 @@ See `NETBOX_OBJECT_TYPES` in `server.py` for complete list.
 ## Environment Variables
 
 - `NETBOX_URL`: Base URL of NetBox instance (e.g., `https://netbox.example.com/`)
-- `NETBOX_TOKEN`: Read-only API token with appropriate permissions
+- `NETBOX_TOKEN`: API token. Read-only is fine for the default tool set; required to have write permissions when `ENABLE_WRITES=true`.
+- `ENABLE_WRITES`: Opt in to `create_object`/`update_object`/`delete_object` tools (default: `false`)
 - `LOG_LEVEL`: Logging verbosity (default: `INFO`, options: `DEBUG`, `WARNING`, `ERROR`)
 
 ## Security Considerations
 
-- **Read-only tokens**: Always use read-only API tokens with minimal required permissions
+- **Minimal-permission tokens**: Use read-only tokens by default. Only grant write permissions when `ENABLE_WRITES=true` is intentionally set, and even then scope the token to the object types you actually need to mutate.
 - **No credential storage**: Tokens passed via environment, never stored or logged
 - **SSL verification**: Enabled by default in REST client
 - **No plugin support**: Deliberately excludes plugin object types to limit attack surface
@@ -197,7 +200,8 @@ Currently no automated test suite. When adding tests:
 
 ### Code Quality
 
-- ❌ Add write operations (create/update/delete) without explicit project maintainer approval
+- ❌ Register write tools unconditionally — they must stay gated behind `ENABLE_WRITES` and `_register_write_tools()`. Never add `@mcp.tool` directly to a write function.
+- ❌ Remove the `confirm=True` requirement on `delete_object` or the `dry_run` parameter on update/delete without explicit user agreement
 - ❌ Add support for plugin object types (scope limited to core NetBox)
 - ❌ Hardcode credentials or NetBox URLs
 - ❌ Bypass the `NetBoxClientBase` abstraction
@@ -296,13 +300,13 @@ Currently no automated test suite. When adding tests:
 
 - Exposes core NetBox functionality not currently accessible
 - Has clear use case for LLM-driven queries
-- Maintains read-only contract
+- Read tools register unconditionally; write tools register only via `_register_write_tools()`
 - Follows existing tool patterns
 
 ❌ **Don't add if**:
 
 - Duplicates existing tool functionality
-- Requires write operations
+- Adds a write tool without going through the `ENABLE_WRITES` gate
 - Only benefits niche use cases
 - Adds complexity without clear value
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NetBox MCP Server
 
+> **Fork notice**: This is a fork of [netboxlabs/netbox-mcp-server](https://github.com/netboxlabs/netbox-mcp-server) that adds opt-in write tools (`create_object`, `update_object`, `delete_object`) behind `ENABLE_WRITES=true`. Upstream is read-only by design; this fork extends that scope. The default behavior matches upstream — write tools never register unless explicitly enabled.
+
 > **⚠️ Breaking Change in v1.0.0**: The project structure has changed.
 > If upgrading from v0.1.0, update your configuration:
 > - Change `uv run server.py` to `uv run netbox-mcp-server`
@@ -7,7 +9,7 @@
 > - Docker users: rebuild images with updated CMD
 > - See [CHANGELOG.md](CHANGELOG.md) for full details
 
-This is a simple read-only [Model Context Protocol](https://modelcontextprotocol.io/) server for NetBox. It enables you to interact with your data in NetBox directly via LLMs that support MCP.
+This is a [Model Context Protocol](https://modelcontextprotocol.io/) server for NetBox. It enables you to interact with your data in NetBox directly via LLMs that support MCP. Read-only by default; opt in to write tools (create/update/delete) via `ENABLE_WRITES=true`.
 
 The server is intentionally simple — easy to get started with, hard to misuse (read-only by default, no plugin surface), and easy to fork and adapt. Forking under Apache 2.0 is a first-class path for users who need capabilities beyond the project's scope.
 
@@ -18,6 +20,16 @@ The server is intentionally simple — easy to get started with, hard to misuse 
 | get_objects | Retrieves NetBox core objects based on their type and filters |
 | get_object_by_id | Gets detailed information about a specific NetBox object by its ID |
 | get_changelogs | Retrieves change history records (audit trail) based on filters |
+
+**Write tools (off by default; set `ENABLE_WRITES=true` to register):**
+
+| Tool | Description |
+|------|-------------|
+| create_object | Creates a NetBox object |
+| update_object | PATCH-updates a NetBox object. Supports `dry_run=True` to preview the diff before committing |
+| delete_object | Deletes a NetBox object. Requires `confirm=True`; supports `dry_run=True` to preview the target |
+
+> ⚠️ **Destructive operations**: `update_object` and `delete_object` modify NetBox state. The API token must have write permissions, and every mutation is logged at INFO level by this server and recorded in NetBox's changelog. `delete_object` requires an explicit `confirm=True` to guard against accidental calls.
 
 > Note: Core NetBox object types are always available. Plugin object types can be auto-discovered — see [Plugin Object Type Discovery](#plugin-object-type-discovery). Advanced features (GraphQL, dynamic model discovery, etc.) are deliberately out of scope — see [CONTRIBUTING.md](CONTRIBUTING.md) for the full scope statement and rationale.
 
@@ -173,6 +185,7 @@ The server supports multiple configuration sources with the following precedence
 | `PORT` | Integer | `8000` | If HTTP | Port for HTTP server |
 | `VERIFY_SSL` | Boolean | `true` | No | Whether to verify SSL certificates |
 | `ENABLE_PLUGIN_DISCOVERY` | Boolean | `false` | No | Auto-discover plugin object types at startup |
+| `ENABLE_WRITES` | Boolean | `false` | No | Register `create_object`/`update_object`/`delete_object` tools. Token must have write permissions in NetBox. |
 | `LOG_LEVEL` | `DEBUG` \| `INFO` \| `WARNING` \| `ERROR` \| `CRITICAL` | `INFO` | No | Logging verbosity |
 
 ### Transport Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "netbox-mcp-server"
 version = "1.1.0"
-description = "A read-only MCP server for NetBox"
+description = "MCP server for NetBox (fork of netboxlabs/netbox-mcp-server with opt-in write tools)"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"
 dependencies = [

--- a/src/netbox_mcp_server/config.py
+++ b/src/netbox_mcp_server/config.py
@@ -38,6 +38,10 @@ class Settings(BaseSettings):
     enable_plugin_discovery: bool = False
     """Whether to auto-discover plugin object types from NetBox at startup"""
 
+    # ===== Write Tool Settings =====
+    enable_writes: bool = False
+    """Whether to register create/update/delete tools. Requires NetBox token with write perms."""
+
     # ===== Security Settings =====
     verify_ssl: bool = True
     """Whether to verify SSL certificates when connecting to NetBox"""
@@ -95,6 +99,7 @@ class Settings(BaseSettings):
             "port": self.port if self.transport == "http" else "N/A",
             "verify_ssl": self.verify_ssl,
             "enable_plugin_discovery": self.enable_plugin_discovery,
+            "enable_writes": self.enable_writes,
             "log_level": self.log_level,
         }
 

--- a/src/netbox_mcp_server/netbox_client.py
+++ b/src/netbox_mcp_server/netbox_client.py
@@ -48,13 +48,20 @@ class NetBoxClientBase(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def create(self, endpoint: str, data: dict[str, Any]) -> dict[str, Any]:
+    def create(
+        self,
+        endpoint: str,
+        data: dict[str, Any],
+        fallback_endpoint: str | None = None,
+    ) -> dict[str, Any]:
         """
         Create a new object in NetBox.
 
         Args:
             endpoint: The API endpoint (e.g., 'dcim/sites', 'ipam/prefixes')
             data: Object data to create
+            fallback_endpoint: Optional alternative endpoint to try if primary returns 404
+                               (used for NetBox version compatibility)
 
         Returns:
             The created object as a dict
@@ -62,7 +69,13 @@ class NetBoxClientBase(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def update(self, endpoint: str, id: int, data: dict[str, Any]) -> dict[str, Any]:
+    def update(
+        self,
+        endpoint: str,
+        id: int,
+        data: dict[str, Any],
+        fallback_endpoint: str | None = None,
+    ) -> dict[str, Any]:
         """
         Update an existing object in NetBox.
 
@@ -70,6 +83,8 @@ class NetBoxClientBase(abc.ABC):
             endpoint: The API endpoint (e.g., 'dcim/sites', 'ipam/prefixes')
             id: ID of the object to update
             data: Object data to update
+            fallback_endpoint: Optional alternative endpoint to try if primary returns 404
+                               (used for NetBox version compatibility)
 
         Returns:
             The updated object as a dict
@@ -77,13 +92,20 @@ class NetBoxClientBase(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete(self, endpoint: str, id: int) -> bool:
+    def delete(
+        self,
+        endpoint: str,
+        id: int,
+        fallback_endpoint: str | None = None,
+    ) -> bool:
         """
         Delete an object from NetBox.
 
         Args:
             endpoint: The API endpoint (e.g., 'dcim/sites', 'ipam/prefixes')
             id: ID of the object to delete
+            fallback_endpoint: Optional alternative endpoint to try if primary returns 404
+                               (used for NetBox version compatibility)
 
         Returns:
             True if deletion was successful, False otherwise
@@ -231,13 +253,20 @@ class NetBoxRestClient(NetBoxClientBase):
 
         return response.json()
 
-    def create(self, endpoint: str, data: dict[str, Any]) -> dict[str, Any]:
+    def create(
+        self,
+        endpoint: str,
+        data: dict[str, Any],
+        fallback_endpoint: str | None = None,
+    ) -> dict[str, Any]:
         """
         Create a new object in NetBox via the REST API.
 
         Args:
             endpoint: The API endpoint (e.g., 'dcim/sites', 'ipam/prefixes')
             data: Object data to create
+            fallback_endpoint: Optional alternative endpoint to try if primary returns 404
+                               (used for NetBox version compatibility)
 
         Returns:
             The created object as a dict
@@ -247,10 +276,21 @@ class NetBoxRestClient(NetBoxClientBase):
         """
         url = self._build_url(endpoint)
         response = self.session.post(url, json=data)
+
+        if response.status_code == 404 and fallback_endpoint:
+            fallback_url = self._build_url(fallback_endpoint)
+            response = self.session.post(fallback_url, json=data)
+
         response.raise_for_status()
         return response.json()
 
-    def update(self, endpoint: str, id: int, data: dict[str, Any]) -> dict[str, Any]:
+    def update(
+        self,
+        endpoint: str,
+        id: int,
+        data: dict[str, Any],
+        fallback_endpoint: str | None = None,
+    ) -> dict[str, Any]:
         """
         Update an existing object in NetBox via the REST API.
 
@@ -258,6 +298,8 @@ class NetBoxRestClient(NetBoxClientBase):
             endpoint: The API endpoint (e.g., 'dcim/sites', 'ipam/prefixes')
             id: ID of the object to update
             data: Object data to update
+            fallback_endpoint: Optional alternative endpoint to try if primary returns 404
+                               (used for NetBox version compatibility)
 
         Returns:
             The updated object as a dict
@@ -267,25 +309,42 @@ class NetBoxRestClient(NetBoxClientBase):
         """
         url = self._build_url(endpoint, id)
         response = self.session.patch(url, json=data)
+
+        if response.status_code == 404 and fallback_endpoint:
+            fallback_url = self._build_url(fallback_endpoint, id)
+            response = self.session.patch(fallback_url, json=data)
+
         response.raise_for_status()
         return response.json()
 
-    def delete(self, endpoint: str, id: int) -> bool:
+    def delete(
+        self,
+        endpoint: str,
+        id: int,
+        fallback_endpoint: str | None = None,
+    ) -> bool:
         """
         Delete an object from NetBox via the REST API.
 
         Args:
             endpoint: The API endpoint (e.g., 'dcim/sites', 'ipam/prefixes')
             id: ID of the object to delete
+            fallback_endpoint: Optional alternative endpoint to try if primary returns 404
+                               (used for NetBox version compatibility)
 
         Returns:
-            True if deletion was successful, False otherwise
+            True if deletion was successful (HTTP 204), False otherwise
 
         Raises:
             httpx.HTTPStatusError: If the request fails
         """
         url = self._build_url(endpoint, id)
         response = self.session.delete(url)
+
+        if response.status_code == 404 and fallback_endpoint:
+            fallback_url = self._build_url(fallback_endpoint, id)
+            response = self.session.delete(fallback_url)
+
         response.raise_for_status()
         return response.status_code == 204
 

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -80,6 +80,15 @@ def parse_cli_args() -> dict[str, Any]:
         help="Auto-discover plugin object types from NetBox at startup",
     )
 
+    # Write tool settings
+    parser.add_argument(
+        "--enable-writes",
+        action="store_true",
+        default=None,
+        dest="enable_writes",
+        help="Register create/update/delete tools (requires NetBox token with write perms)",
+    )
+
     # Observability settings
     parser.add_argument(
         "--log-level",
@@ -105,6 +114,8 @@ def parse_cli_args() -> dict[str, Any]:
         overlay["verify_ssl"] = args.verify_ssl
     if args.enable_plugin_discovery is not None:
         overlay["enable_plugin_discovery"] = args.enable_plugin_discovery
+    if args.enable_writes is not None:
+        overlay["enable_writes"] = args.enable_writes
     if args.log_level is not None:
         overlay["log_level"] = args.log_level
 
@@ -311,7 +322,7 @@ def netbox_get_objects(
 @mcp.tool
 def netbox_get_object_by_id(
     object_type: str,
-    object_id: int,
+    object_id: Annotated[int, Field(ge=1)],
     fields: list[str] | None = None,
     brief: bool = False,
 ):
@@ -359,6 +370,183 @@ def netbox_get_object_by_id(
         params["brief"] = "1"
 
     return netbox.get(full_endpoint, params=params, fallback_endpoint=full_fallback)
+
+
+def _httpx_error_to_value_error(exc: httpx.HTTPStatusError) -> ValueError:
+    """Convert an httpx.HTTPStatusError into a ValueError including NetBox's response body.
+
+    NetBox returns structured field-level errors in 4xx response bodies
+    (e.g. {"name": ["This field is required."]}). Surfacing that detail to the
+    LLM gives it enough context to retry the call with corrected input.
+    """
+    try:
+        detail: Any = exc.response.json()
+    except ValueError:
+        detail = exc.response.text[:500]
+    return ValueError(f"NetBox API error {exc.response.status_code}: {detail}")
+
+
+def netbox_create_object(
+    object_type: str,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Create a new object in NetBox.
+
+    Args:
+        object_type: String representing the NetBox object type (e.g. "dcim.device", "ipam.ipaddress")
+        data: Field values for the new object. Required fields depend on the object type;
+              consult NetBox API docs or call netbox_get_objects to see existing examples.
+              Foreign keys generally accept either a numeric id or a natural slug.
+
+    Returns:
+        The created object as a dict (includes server-assigned id, url, created, etc.).
+    """
+    if object_type not in NETBOX_OBJECT_TYPES:
+        valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
+        raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
+
+    if not data:
+        raise ValueError("data must be a non-empty dict")
+
+    logger = logging.getLogger(__name__)
+    endpoint, fallback = _get_endpoint_info(object_type)
+    logger.info(f"netbox_create_object: {object_type} fields={sorted(data.keys())}")
+    try:
+        result = netbox.create(endpoint, data, fallback_endpoint=fallback)
+    except httpx.HTTPStatusError as e:
+        raise _httpx_error_to_value_error(e) from e
+    logger.info(f"netbox_create_object: {object_type} created id={result.get('id')}")
+    return result
+
+
+def netbox_update_object(
+    object_type: str,
+    object_id: Annotated[int, Field(ge=1)],
+    data: dict[str, Any],
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """
+    Partial update (PATCH) of an existing NetBox object.
+
+    Args:
+        object_type: String representing the NetBox object type (e.g. "dcim.device")
+        object_id: The numeric ID of the object to update
+        data: Fields to change. PATCH semantics — only listed fields are modified;
+              omitted fields are left as-is.
+        dry_run: If True, fetch the current object and return the intended diff
+                 without sending the PATCH. Use this to preview a change before
+                 committing to it.
+
+    Returns:
+        On a real call: the updated object as a dict.
+        On dry_run: {"dry_run": True, "object_type": ..., "object_id": ...,
+                     "current": <subset of current values for the changed fields>,
+                     "proposed": <data>}.
+    """
+    if object_type not in NETBOX_OBJECT_TYPES:
+        valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
+        raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
+
+    if not data:
+        raise ValueError("data must be a non-empty dict")
+
+    logger = logging.getLogger(__name__)
+    endpoint, fallback = _get_endpoint_info(object_type)
+
+    if dry_run:
+        logger.info(
+            f"netbox_update_object[dry_run]: {object_type} id={object_id} "
+            f"fields={sorted(data.keys())}"
+        )
+        try:
+            current = netbox.get(endpoint, id=object_id, fallback_endpoint=fallback)
+        except httpx.HTTPStatusError as e:
+            raise _httpx_error_to_value_error(e) from e
+        current_subset = {k: current.get(k) for k in data}
+        return {
+            "dry_run": True,
+            "object_type": object_type,
+            "object_id": object_id,
+            "current": current_subset,
+            "proposed": data,
+        }
+
+    logger.info(
+        f"netbox_update_object: {object_type} id={object_id} fields={sorted(data.keys())}"
+    )
+    try:
+        result = netbox.update(endpoint, object_id, data, fallback_endpoint=fallback)
+    except httpx.HTTPStatusError as e:
+        raise _httpx_error_to_value_error(e) from e
+    logger.info(f"netbox_update_object: {object_type} id={object_id} updated")
+    return result
+
+
+def netbox_delete_object(
+    object_type: str,
+    object_id: Annotated[int, Field(ge=1)],
+    confirm: bool = False,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """
+    Delete a NetBox object. Cannot be undone.
+
+    Args:
+        object_type: String representing the NetBox object type (e.g. "dcim.device")
+        object_id: The numeric ID of the object to delete
+        confirm: Must be set to True for a real delete to proceed. Guards against
+                 the LLM calling delete with default arguments. Ignored when dry_run=True.
+        dry_run: If True, fetch the target object and return what would be deleted
+                 without issuing the DELETE.
+
+    Returns:
+        On a real call: {"deleted": True, "object_type": ..., "object_id": ...}.
+        On dry_run: {"dry_run": True, "object_type": ..., "object_id": ...,
+                     "target": <current object>}.
+    """
+    if object_type not in NETBOX_OBJECT_TYPES:
+        valid_types = "\n".join(f"- {t}" for t in sorted(NETBOX_OBJECT_TYPES.keys()))
+        raise ValueError(f"Invalid object_type. Must be one of:\n{valid_types}")
+
+    logger = logging.getLogger(__name__)
+    endpoint, fallback = _get_endpoint_info(object_type)
+
+    if dry_run:
+        logger.info(
+            f"netbox_delete_object[dry_run]: {object_type} id={object_id}"
+        )
+        try:
+            target = netbox.get(endpoint, id=object_id, fallback_endpoint=fallback)
+        except httpx.HTTPStatusError as e:
+            raise _httpx_error_to_value_error(e) from e
+        return {
+            "dry_run": True,
+            "object_type": object_type,
+            "object_id": object_id,
+            "target": target,
+        }
+
+    if not confirm:
+        raise ValueError(
+            "Refusing to delete without explicit confirm=True. Pass confirm=True "
+            "to proceed, or dry_run=True to preview the target."
+        )
+
+    logger.info(f"netbox_delete_object: {object_type} id={object_id} deleting")
+    try:
+        deleted = netbox.delete(endpoint, object_id, fallback_endpoint=fallback)
+    except httpx.HTTPStatusError as e:
+        raise _httpx_error_to_value_error(e) from e
+
+    if not deleted:
+        raise RuntimeError(
+            f"Delete of {object_type} id={object_id} returned a non-204 success "
+            "status; the object may not have been removed. Re-check via netbox_get_object_by_id."
+        )
+
+    logger.info(f"netbox_delete_object: {object_type} id={object_id} deleted")
+    return {"deleted": True, "object_type": object_type, "object_id": object_id}
 
 
 @mcp.tool
@@ -643,6 +831,17 @@ async def _update_tool_descriptions() -> None:
             tool.description = f"{prefix}\n\n{type_list}{suffix}"
 
 
+def _register_write_tools(mcp_instance: FastMCP) -> None:
+    """Register write tools on the given FastMCP instance.
+
+    Called from main() only when settings.enable_writes is True, so the
+    tools are absent from tools/list by default.
+    """
+    mcp_instance.tool(netbox_create_object)
+    mcp_instance.tool(netbox_update_object)
+    mcp_instance.tool(netbox_delete_object)
+
+
 def main() -> None:
     """Main entry point for the MCP server."""
     global netbox
@@ -698,6 +897,18 @@ def main() -> None:
         if plugin_types:
             NETBOX_OBJECT_TYPES.update(plugin_types)
             asyncio.run(_update_tool_descriptions())
+
+    if settings.enable_writes:
+        _register_write_tools(mcp)
+        if settings.transport == "http":
+            bind = f"http://{settings.host}:{settings.port}"
+        else:
+            bind = "stdio"
+        logger.warning(
+            f"Write tools ENABLED ({bind}). NetBox API token must have write "
+            "permissions; all mutations are recorded in NetBox's changelog. "
+            "Verify the bind address is not exposed to untrusted networks."
+        )
 
     try:
         if settings.transport == "stdio":

--- a/tests/test_client_fallback.py
+++ b/tests/test_client_fallback.py
@@ -284,3 +284,108 @@ def test_fallback_builds_correct_url(client):
 
         fallback_url = mock_get.call_args_list[1][0][0]
         assert fallback_url == "https://netbox.example.com/api/extras/object-types/"
+
+
+# ============================================================================
+# Write methods: fallback parity with get()
+# ============================================================================
+
+
+def test_create_falls_back_on_404(client):
+    """create() should retry on the fallback endpoint when primary 404s."""
+    primary = MagicMock()
+    primary.status_code = 404
+
+    fallback = MagicMock()
+    fallback.status_code = 201
+    fallback.json.return_value = {"id": 1, "name": "x"}
+    fallback.raise_for_status = MagicMock()
+
+    with patch.object(client.session, "post") as mock_post:
+        mock_post.side_effect = [primary, fallback]
+
+        result = client.create(
+            "vpn/tunnels",
+            {"name": "x"},
+            fallback_endpoint="plugins/vpn/tunnels",
+        )
+
+        assert mock_post.call_count == 2
+        assert "vpn/tunnels" in mock_post.call_args_list[0][0][0]
+        assert "plugins/vpn/tunnels" in mock_post.call_args_list[1][0][0]
+        assert result == {"id": 1, "name": "x"}
+
+
+def test_create_does_not_fall_back_on_400(client):
+    """A 400 (validation error) must surface immediately, not retry."""
+    primary = MagicMock()
+    primary.status_code = 400
+    primary.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "bad request", request=MagicMock(), response=MagicMock()
+    )
+
+    with patch.object(client.session, "post") as mock_post:
+        mock_post.return_value = primary
+
+        with pytest.raises(httpx.HTTPStatusError):
+            client.create(
+                "vpn/tunnels",
+                {"name": "x"},
+                fallback_endpoint="plugins/vpn/tunnels",
+            )
+
+        assert mock_post.call_count == 1
+
+
+def test_update_falls_back_on_404(client):
+    primary = MagicMock()
+    primary.status_code = 404
+
+    fallback = MagicMock()
+    fallback.status_code = 200
+    fallback.json.return_value = {"id": 1, "name": "renamed"}
+    fallback.raise_for_status = MagicMock()
+
+    with patch.object(client.session, "patch") as mock_patch:
+        mock_patch.side_effect = [primary, fallback]
+
+        result = client.update(
+            "vpn/tunnels",
+            1,
+            {"name": "renamed"},
+            fallback_endpoint="plugins/vpn/tunnels",
+        )
+
+        assert mock_patch.call_count == 2
+        assert result == {"id": 1, "name": "renamed"}
+
+
+def test_delete_falls_back_on_404(client):
+    primary = MagicMock()
+    primary.status_code = 404
+
+    fallback = MagicMock()
+    fallback.status_code = 204
+    fallback.raise_for_status = MagicMock()
+
+    with patch.object(client.session, "delete") as mock_delete:
+        mock_delete.side_effect = [primary, fallback]
+
+        assert client.delete(
+            "vpn/tunnels",
+            1,
+            fallback_endpoint="plugins/vpn/tunnels",
+        ) is True
+        assert mock_delete.call_count == 2
+
+
+def test_delete_returns_false_on_non_204_success(client):
+    """The bool return reflects 204; tool layer turns False into an error."""
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+
+    with patch.object(client.session, "delete") as mock_delete:
+        mock_delete.return_value = response
+
+        assert client.delete("dcim/sites", 1) is False

--- a/tests/test_write_registration.py
+++ b/tests/test_write_registration.py
@@ -1,0 +1,103 @@
+"""Tests that write tools are only registered when explicitly opted in.
+
+This is the safety contract: if ENABLE_WRITES is unset (default), the three
+write tools must not appear in tools/list. The gating boundary is the
+_register_write_tools() helper — main() only calls it when
+settings.enable_writes is True.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from netbox_mcp_server import server as server_module
+from netbox_mcp_server.server import _register_write_tools
+
+WRITE_TOOL_NAMES = {
+    "netbox_create_object",
+    "netbox_update_object",
+    "netbox_delete_object",
+}
+
+
+def _tool_names(mcp_instance: FastMCP) -> set[str]:
+    tools = asyncio.run(mcp_instance.list_tools())
+    return {t.name for t in tools}
+
+
+def test_writes_not_registered_when_helper_not_called():
+    """When _register_write_tools is not called, write tools are absent."""
+    mcp = FastMCP("test")
+    assert _tool_names(mcp) & WRITE_TOOL_NAMES == set()
+
+
+def test_module_level_mcp_has_no_write_tools_at_import():
+    """Regression guard: nobody slapped @mcp.tool on the write functions.
+
+    The module-level FastMCP instance must not carry write tools at import
+    time — registration only happens in main() when settings.enable_writes
+    is True. If this fails, someone added a decorator that defeats the gate.
+    """
+    assert _tool_names(server_module.mcp) & WRITE_TOOL_NAMES == set()
+
+
+def test_writes_registered_when_helper_called():
+    """When _register_write_tools is called, all three write tools are present."""
+    mcp = FastMCP("test")
+    _register_write_tools(mcp)
+    assert WRITE_TOOL_NAMES.issubset(_tool_names(mcp))
+
+
+@pytest.mark.parametrize("tool_name", sorted(WRITE_TOOL_NAMES))
+def test_each_write_tool_registered_individually(tool_name):
+    """Each write tool is reachable via get_tool after registration."""
+    mcp = FastMCP("test")
+    _register_write_tools(mcp)
+    tool = asyncio.run(mcp.get_tool(tool_name))
+    assert tool is not None
+    assert tool.name == tool_name
+
+
+# ============================================================================
+# main() wiring: enable_writes setting controls registration
+# ============================================================================
+
+
+def _stub_main_deps(monkeypatch, *, enable_writes: bool):
+    """Patch out main()'s side effects so we can assert only the gating logic."""
+    settings = MagicMock()
+    settings.log_level = "INFO"
+    settings.verify_ssl = True
+    settings.transport = "stdio"
+    settings.host = "127.0.0.1"
+    settings.port = 8000
+    settings.enable_plugin_discovery = False
+    settings.enable_writes = enable_writes
+    settings.netbox_url = "https://nb.example.com/"
+    settings.netbox_token = MagicMock()
+    settings.netbox_token.get_secret_value.return_value = "tok"
+    settings.get_effective_config_summary.return_value = {}
+
+    monkeypatch.setattr(server_module, "parse_cli_args", lambda: {})
+    monkeypatch.setattr(server_module, "Settings", lambda **_: settings)
+    monkeypatch.setattr(server_module, "configure_logging", lambda _: None)
+    monkeypatch.setattr(server_module, "NetBoxRestClient", lambda **_: MagicMock())
+
+    # mcp.run would block; replace with no-op.
+    monkeypatch.setattr(server_module.mcp, "run", lambda **_: None)
+
+
+def test_main_does_not_register_writes_when_setting_false(monkeypatch):
+    _stub_main_deps(monkeypatch, enable_writes=False)
+    with patch.object(server_module, "_register_write_tools") as mock_reg:
+        server_module.main()
+        mock_reg.assert_not_called()
+
+
+def test_main_registers_writes_when_setting_true(monkeypatch):
+    _stub_main_deps(monkeypatch, enable_writes=True)
+    with patch.object(server_module, "_register_write_tools") as mock_reg:
+        server_module.main()
+        mock_reg.assert_called_once_with(server_module.mcp)

--- a/tests/test_writes.py
+++ b/tests/test_writes.py
@@ -1,0 +1,222 @@
+"""Tests for write tool behavior (create/update/delete)."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from netbox_mcp_server.server import (
+    netbox_create_object,
+    netbox_delete_object,
+    netbox_update_object,
+)
+
+
+# ============================================================================
+# Create
+# ============================================================================
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_create_object_happy_path(mock_netbox):
+    mock_netbox.create.return_value = {"id": 42, "name": "test-site"}
+
+    result = netbox_create_object(
+        object_type="dcim.site",
+        data={"name": "test-site", "slug": "test-site"},
+    )
+
+    mock_netbox.create.assert_called_once_with(
+        "dcim/sites",
+        {"name": "test-site", "slug": "test-site"},
+        fallback_endpoint=None,
+    )
+    assert result == {"id": 42, "name": "test-site"}
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_create_object_invalid_type(mock_netbox):
+    with pytest.raises(ValueError, match="Invalid object_type"):
+        netbox_create_object(object_type="not.a.real.type", data={"name": "x"})
+    mock_netbox.create.assert_not_called()
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_create_object_empty_data(mock_netbox):
+    with pytest.raises(ValueError, match="non-empty"):
+        netbox_create_object(object_type="dcim.site", data={})
+    mock_netbox.create.assert_not_called()
+
+
+@patch("netbox_mcp_server.server.NETBOX_OBJECT_TYPES")
+@patch("netbox_mcp_server.server.netbox")
+def test_create_object_passes_fallback_endpoint(mock_netbox, mock_types):
+    """fallback_endpoint from NETBOX_OBJECT_TYPES is forwarded to the client."""
+    mock_types.__contains__.return_value = True
+    mock_types.__getitem__.return_value = {
+        "endpoint": "vpn/tunnels",
+        "fallback_endpoint": "plugins/vpn/tunnels",
+    }
+    mock_netbox.create.return_value = {"id": 1}
+
+    netbox_create_object(object_type="vpn.tunnel", data={"name": "t"})
+
+    mock_netbox.create.assert_called_once_with(
+        "vpn/tunnels", {"name": "t"}, fallback_endpoint="plugins/vpn/tunnels"
+    )
+
+
+# ============================================================================
+# Update
+# ============================================================================
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_update_object_happy_path(mock_netbox):
+    mock_netbox.update.return_value = {"id": 7, "name": "renamed"}
+
+    result = netbox_update_object(
+        object_type="dcim.site",
+        object_id=7,
+        data={"name": "renamed"},
+    )
+
+    mock_netbox.update.assert_called_once_with(
+        "dcim/sites", 7, {"name": "renamed"}, fallback_endpoint=None
+    )
+    assert result == {"id": 7, "name": "renamed"}
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_update_object_invalid_type(mock_netbox):
+    with pytest.raises(ValueError, match="Invalid object_type"):
+        netbox_update_object(object_type="not.real", object_id=1, data={"name": "x"})
+    mock_netbox.update.assert_not_called()
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_update_object_empty_data(mock_netbox):
+    with pytest.raises(ValueError, match="non-empty"):
+        netbox_update_object(object_type="dcim.site", object_id=1, data={})
+    mock_netbox.update.assert_not_called()
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_update_object_dry_run_returns_diff_without_patch(mock_netbox):
+    """dry_run=True fetches the current object and never calls update."""
+    mock_netbox.get.return_value = {
+        "id": 7,
+        "name": "old",
+        "description": "unchanged",
+    }
+
+    result = netbox_update_object(
+        object_type="dcim.site",
+        object_id=7,
+        data={"name": "new"},
+        dry_run=True,
+    )
+
+    mock_netbox.get.assert_called_once_with("dcim/sites", id=7, fallback_endpoint=None)
+    mock_netbox.update.assert_not_called()
+    assert result == {
+        "dry_run": True,
+        "object_type": "dcim.site",
+        "object_id": 7,
+        "current": {"name": "old"},
+        "proposed": {"name": "new"},
+    }
+
+
+# ============================================================================
+# Delete
+# ============================================================================
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_delete_object_happy_path(mock_netbox):
+    mock_netbox.delete.return_value = True
+
+    result = netbox_delete_object(
+        object_type="dcim.site", object_id=99, confirm=True
+    )
+
+    mock_netbox.delete.assert_called_once_with(
+        "dcim/sites", 99, fallback_endpoint=None
+    )
+    assert result == {"deleted": True, "object_type": "dcim.site", "object_id": 99}
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_delete_object_requires_confirm(mock_netbox):
+    """Without confirm=True, delete refuses and never hits the client."""
+    with pytest.raises(ValueError, match="confirm=True"):
+        netbox_delete_object(object_type="dcim.site", object_id=99)
+    mock_netbox.delete.assert_not_called()
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_delete_object_raises_when_client_returns_false(mock_netbox):
+    """Non-204 success must surface as an error, not a silent 'deleted: True'."""
+    mock_netbox.delete.return_value = False
+
+    with pytest.raises(RuntimeError, match="non-204"):
+        netbox_delete_object(object_type="dcim.site", object_id=99, confirm=True)
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_delete_object_invalid_type(mock_netbox):
+    with pytest.raises(ValueError, match="Invalid object_type"):
+        netbox_delete_object(object_type="not.real", object_id=1, confirm=True)
+    mock_netbox.delete.assert_not_called()
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_delete_object_dry_run_returns_target_without_deleting(mock_netbox):
+    """dry_run=True fetches the target and never calls delete (confirm irrelevant)."""
+    mock_netbox.get.return_value = {"id": 99, "name": "doomed"}
+
+    result = netbox_delete_object(
+        object_type="dcim.site", object_id=99, dry_run=True
+    )
+
+    mock_netbox.get.assert_called_once_with("dcim/sites", id=99, fallback_endpoint=None)
+    mock_netbox.delete.assert_not_called()
+    assert result == {
+        "dry_run": True,
+        "object_type": "dcim.site",
+        "object_id": 99,
+        "target": {"id": 99, "name": "doomed"},
+    }
+
+
+# ============================================================================
+# Error translation
+# ============================================================================
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_http_error_translated_to_value_error_with_json_body(mock_netbox):
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 400
+    response.json.return_value = {"name": ["This field is required."]}
+    mock_netbox.create.side_effect = httpx.HTTPStatusError(
+        "400 Bad Request", request=MagicMock(), response=response
+    )
+
+    with pytest.raises(ValueError, match="This field is required"):
+        netbox_create_object(object_type="dcim.site", data={"slug": "x"})
+
+
+@patch("netbox_mcp_server.server.netbox")
+def test_http_error_falls_back_to_text_when_body_not_json(mock_netbox):
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 500
+    response.json.side_effect = ValueError("not json")
+    response.text = "Internal Server Error"
+    mock_netbox.update.side_effect = httpx.HTTPStatusError(
+        "500 Server Error", request=MagicMock(), response=response
+    )
+
+    with pytest.raises(ValueError, match="Internal Server Error"):
+        netbox_update_object(object_type="dcim.site", object_id=1, data={"name": "x"})


### PR DESCRIPTION
Adds three write tools — `netbox_create_object`, `netbox_update_object`, `netbox_delete_object` — gated behind `ENABLE_WRITES=true`. The default tool surface remains read-only and matches upstream; writes only register when explicitly enabled via env var or `--enable-writes`.

Safety surface:
- `delete_object` requires explicit `confirm=True` to proceed
- `update_object` and `delete_object` support `dry_run=True` to preview the change without mutating
- Every mutation is logged at INFO by the tool layer in addition to NetBox's changelog
- Startup warning includes the bind address so an exposed HTTP server with writes enabled stands out

Client changes:
- `NetBoxClientBase.create/update/delete` and `NetBoxRestClient` now accept `fallback_endpoint` for pre-4.4 NetBox compatibility, mirroring the read path
- `netbox_delete_object` honors the client's bool return — non-204 success raises rather than silently claiming `deleted: True`

Also constrains `object_id` with `Field(ge=1)` on the new write tools and on the pre-existing `netbox_get_object_by_id`.

Docs updated to reflect this fork's identity (write tools as a first-class opt-in feature). CONTRIBUTING.md left as-is since it describes the upstream project's scope.