### PR TITLE
ci: add PyPI publish workflow with Trusted Publisher OIDC

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,82 @@
+name: Publish to PyPI
+
+# Publishes the sdist and wheel to PyPI on every `v*.*.*` tag created by
+# `release-finalize.yml`. Uses PyPI Trusted Publishers (OIDC) — no API
+# token is stored in the repo; the `id-token: write` permission lets the
+# publish job mint a short-lived credential that PyPI accepts.
+#
+# Setup requirements (one-time, owned by the `netboxlabs-publisher` PyPI
+# account):
+#   1. Configure a trusted publisher (or pending publisher, if the name
+#      has not been claimed yet) on PyPI for project `netbox-mcp-server`
+#      pointing at:
+#        - owner:       netboxlabs
+#        - repository:  netbox-mcp-server
+#        - workflow:    pypi-publish.yml
+#        - environment: pypi
+#   2. Create the `pypi` GitHub Environment in repo Settings, with a
+#      deployment branch/tag rule restricting it to tags matching `v*`.
+#
+# See https://docs.pypi.org/trusted-publishers/ for background.
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pypi-publish-${{ github.ref }}
+
+jobs:
+  build:
+    name: Build sdist and wheel
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/project/netbox-mcp-server/
+    permissions:
+      contents: read
+      id-token: write     # required for Trusted Publisher OIDC exchange
+      attestations: write # SLSA build provenance, matching docker-publish.yml
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Generate SLSA build provenance attestation
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
+        with:
+          subject-path: "dist/*"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds a PyPI publish workflow so a `v*.*.*` tag — already produced by `release-finalize.yml` — also pushes the sdist and wheel to PyPI. Uses [PyPI Trusted Publishers](https://docs.pypi.org/trusted-publishers/) (OIDC), so no API token is stored in the repo.

The build and publish steps are split across two jobs so the OIDC token (`id-token: write`) is only present in the publish job, not while `uv build` is running — same pattern the existing `docker-publish.yml` uses for its build/merge split. SLSA build provenance is attested for the uploaded artifacts, matching the docker workflow.

## Draft — do not merge yet

Merging this workflow alone publishes nothing; the OIDC exchange fails closed without the matching PyPI-side registration. Before this can land, the holder of the `netboxlabs-publisher` PyPI account needs to:

- [ ] Configure a trusted publisher (or pending publisher, since the project doesn't exist yet) on PyPI for `netbox-mcp-server`, pointing at:
  - owner: `netboxlabs`
  - repo: `netbox-mcp-server`
  - workflow: `pypi-publish.yml`
  - environment: `pypi`
- [ ] Create the `pypi` GitHub Environment in repo Settings → Environments, with a deployment branch/tag rule restricting it to `v*` tags
- [ ] Optionally require a reviewer on the `pypi` environment for the first run

The workflow header in `pypi-publish.yml` documents these steps inline so the access holder can configure straight from the file.

## Verification done locally

- `uv build` produces `netbox_mcp_server-1.2.0.tar.gz` (188K) and `netbox_mcp_server-1.2.0-py3-none-any.whl` (25K)
- `[project.scripts]` already wires `netbox-mcp-server` → `netbox_mcp_server.server:main`, so `uvx netbox-mcp-server` will work once published

Relates to #130.