### PR TITLE
fix(server): add optional bearer token auth for HTTP transport

### DIFF
--- a/src/netbox_mcp_server/config.py
+++ b/src/netbox_mcp_server/config.py
@@ -48,6 +48,16 @@ class Settings(BaseSettings):
     verify_ssl: bool = True
     """Whether to verify SSL certificates when connecting to NetBox"""
 
+    mcp_auth_token: SecretStr | None = Field(
+        default=None,
+        description=(
+            "Bearer token required to access the HTTP transport endpoint. "
+            "If set, all requests must include 'Authorization: Bearer <token>'. "
+            "Has no effect when transport=stdio."
+        ),
+    )
+    """Optional bearer token to protect the HTTP transport endpoint"""
+
     # ===== Observability Settings =====
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
     """Logging verbosity level"""
@@ -121,6 +131,7 @@ class Settings(BaseSettings):
                     "host": self.host,
                     "port": self.port,
                     "cors_origins": self.cors_origins,
+                    "mcp_auth_token": "***REDACTED***" if self.mcp_auth_token else None,
                 }
             )
         return summary

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import hmac
 import logging
 import sys
 from typing import Annotated, Any
@@ -8,11 +9,35 @@ import httpx
 from fastmcp import FastMCP
 from pydantic import Field
 from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from netbox_mcp_server.config import Settings, configure_logging
 from netbox_mcp_server.netbox_client import NetBoxRestClient
 from netbox_mcp_server.netbox_types import NETBOX_OBJECT_TYPES
+
+
+class BearerTokenMiddleware(BaseHTTPMiddleware):
+    """Enforce Bearer token authentication on the HTTP transport endpoint."""
+
+    def __init__(self, app: Any, token: str) -> None:
+        super().__init__(app)
+        self._token = token
+
+    async def dispatch(self, request: Request, call_next: Any) -> Any:
+        if request.method == "OPTIONS":
+            # Allow CORS preflight through unconditionally
+            return await call_next(request)
+        auth = request.headers.get("Authorization", "")
+        provided = auth[7:] if auth.startswith("Bearer ") else ""
+        if not hmac.compare_digest(provided, self._token):
+            return JSONResponse(
+                {"error": "Unauthorized", "detail": "Valid Bearer token required"},
+                status_code=401,
+            )
+        return await call_next(request)
 
 
 def parse_cli_args() -> dict[str, Any]:
@@ -728,6 +753,9 @@ def main() -> None:
             mcp.run(transport="stdio")
         elif settings.transport == "http":
             logger.info(f"Starting HTTP transport on {settings.host}:{settings.port}")
+            # CORSMiddleware runs first so 401 responses include CORS headers,
+            # allowing browser-based clients to read the error response.
+            # BearerTokenMiddleware runs second to enforce authentication.
             middleware = [
                 Middleware(
                     CORSMiddleware,
@@ -741,6 +769,13 @@ def main() -> None:
                     expose_headers=["mcp-session-id"],
                 )
             ]
+            if settings.mcp_auth_token:
+                middleware.append(
+                    Middleware(
+                        BearerTokenMiddleware,
+                        token=settings.mcp_auth_token.get_secret_value(),
+                    )
+                )
             mcp.run(transport="http", host=settings.host, port=settings.port, middleware=middleware)
     except Exception as e:
         logger.error(f"Failed to start MCP server: {e}")


### PR DESCRIPTION
### Fixes issue #152 

The HTTP transport had no authentication - any client that could reach the port got a valid MCP session and full access to all NetBox tools. This adds an optional `MCP_AUTH_TOKEN` env var. When set, all requests must include ```Authorization: Bearer <token>```. When not set, nothing changes.

**What changed**

`config.py` - one new optional field under Security Settings:

```python
mcp_auth_token: SecretStr | None = Field(
    default=None,
    description=(
        "Bearer token required to access the HTTP transport endpoint. "
        "If set, all requests must include 'Authorization: Bearer <token>'. "
        "Has no effect when transport=stdio."
    ),
)
```

`server.py` - new `BearerTokenMiddleware` wired into the HTTP transport middleware list. `hmac.compare_digest` is used instead of `==` to avoid timing differences. `CORSMiddleware` is placed first so 401 responses carry CORS headers and browser clients can read the error.

**Tested**
```
- No auth → 401
- Wrong token → 401
- Correct token → 200, session granted, all 4 tools work
- OPTIONS preflight → 200, no session granted
- `MCP_AUTH_TOKEN` not set → identical to v1.2.0
- `stdio` transport → unaffected
- 85/85 existing tests pass
```
Also worth updating the three Docker examples in the README that use `HOST=0.0.0.0` to include `-e MCP_AUTH_TOKEN=<token>`