### PR TITLE
chore(renovate): raise stability window to 7-day org standard

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -23,7 +23,7 @@
       matchManagers: ['pep621', 'uv'],
       matchUpdateTypes: ['minor', 'patch'],
       groupName: 'non-major Python dependencies',
-      minimumReleaseAge: '3 days',
+      minimumReleaseAge: '7 days',
     },
 
     // GitHub Actions
@@ -33,7 +33,7 @@
       pinDigests: true,
       matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
       groupName: 'non-major GitHub Actions',
-      minimumReleaseAge: '3 days',
+      minimumReleaseAge: '7 days',
     },
 
     // Docker
@@ -42,7 +42,7 @@
       matchManagers: ['dockerfile'],
       matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
       groupName: 'non-major Docker dependencies',
-      minimumReleaseAge: '3 days',
+      minimumReleaseAge: '7 days',
     },
 
     // Major updates always separate for manual review


### PR DESCRIPTION
Raises Renovate's `minimumReleaseAge` to 7 days, the org-standard stability window for dependency updates. Routine updates now wait 7 days after release before a PR opens, reducing exposure to freshly published versions. Security/vulnerability-driven updates (`vulnerabilityAlerts`) are unaffected.

Note for npm lockfile repos: Renovate 43+ enforces this window during lockfile generation (npm `--before`). Any `package.json` range floor currently aged 3–6 days will transiently fail artifact updates until it ages past 7 days — self-heals, no action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
