### PR TITLE
chore(renovate): add top-level minimumReleaseAge for full coverage

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,10 @@
   // Bump lower bounds in pyproject.toml even when the constraint already allows the new version
   rangeStrategy: 'bump',
 
+  // Org-standard stability window — applies to every update not matched by a
+  // more specific packageRule below (rule-level values override this).
+  minimumReleaseAge: '7 days',
+
   packageRules: [
     // Don't bump requires-python — it defines minimum supported version, not installed version
     {


### PR DESCRIPTION
Follow-up to the merged 7-day stability window PR: the window only lived in scoped `packageRules`, so updates not matched by those rules had no stability gate. A top-level `minimumReleaseAge` covers every update; rule-level values (including the security bypass) still override it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)