### PR TITLE
chore(renovate): extend the central org preset

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['config:recommended', ':dependencyDashboard', ':semanticCommits'],
+  extends: ['github>netboxlabs/renovate', 'config:recommended', ':dependencyDashboard', ':semanticCommits'],
 
   // Schedule inherited from central config.js (before 4am UTC on weekdays)
 
@@ -8,10 +8,6 @@
 
   // Bump lower bounds in pyproject.toml even when the constraint already allows the new version
   rangeStrategy: 'bump',
-
-  // Org-standard stability window — applies to every update not matched by a
-  // more specific packageRule below (rule-level values override this).
-  minimumReleaseAge: '7 days',
 
   packageRules: [
     // Don't bump requires-python — it defines minimum supported version, not installed version
@@ -27,7 +23,6 @@
       matchManagers: ['pep621', 'uv'],
       matchUpdateTypes: ['minor', 'patch'],
       groupName: 'non-major Python dependencies',
-      minimumReleaseAge: '7 days',
     },
 
     // GitHub Actions
@@ -37,7 +32,6 @@
       pinDigests: true,
       matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
       groupName: 'non-major GitHub Actions',
-      minimumReleaseAge: '7 days',
     },
 
     // Docker
@@ -46,7 +40,6 @@
       matchManagers: ['dockerfile'],
       matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
       groupName: 'non-major Docker dependencies',
-      minimumReleaseAge: '7 days',
     },
 
     // Major updates always separate for manual review

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,11 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['github>netboxlabs/renovate', 'config:recommended', ':dependencyDashboard', ':semanticCommits'],
-
+  extends: [
+    'github>netboxlabs/renovate',
+    'config:recommended',
+    ':dependencyDashboard',
+    ':semanticCommits',
+  ],
   // Schedule inherited from central config.js (before 4am UTC on weekdays)
 
   labels: ['dependencies'],


### PR DESCRIPTION
Switches this repo's Renovate config onto the shared org preset (netboxlabs/renovate `default.json`, merged in netboxlabs/renovate#42): the 7-day stability window, strict pending-version filtering, and CVE bypass are now inherited via `extends` instead of hand-copied keys — so the standard can't drift per-repo again. Behavior is unchanged; this removes duplication only.

Note: this is a public repo referencing a preset in a private repo. It resolves in our centrally-run Renovate (App token); external `renovate-config-validator` runs cannot fetch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)