### PR TITLE
fix(transport): add optional bearer token authentication for HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The server supports multiple configuration sources with the following precedence
 | `TRANSPORT` | `stdio` \| `http` | `stdio` | No | MCP transport protocol |
 | `HOST` | String | `127.0.0.1` | If HTTP | Host address for HTTP server |
 | `PORT` | Integer | `8000` | If HTTP | Port for HTTP server |
+| `MCP_AUTH_TOKEN` | String | - | No | Bearer token required on the HTTP endpoint. When unset, the HTTP transport is unauthenticated. Clients send `Authorization: Bearer <token>`. |
 | `VERIFY_SSL` | Boolean | `true` | No | Whether to verify SSL certificates |
 | `ENABLE_PLUGIN_DISCOVERY` | Boolean | `false` | No | Auto-discover plugin object types at startup |
 | `LOG_LEVEL` | `DEBUG` \| `INFO` \| `WARNING` \| `ERROR` \| `CRITICAL` | `INFO` | No | Logging verbosity |
@@ -238,6 +239,8 @@ TRANSPORT=stdio
 # HTTP Transport Settings (only used if TRANSPORT=http)
 # HOST=127.0.0.1
 # PORT=8000
+# Bearer token required on the HTTP endpoint. When unset, the endpoint is unauthenticated.
+# MCP_AUTH_TOKEN=a-strong-random-token
 
 # Security (optional, defaults to true)
 VERIFY_SSL=true
@@ -303,11 +306,14 @@ docker run --rm \
   -e TRANSPORT=http \
   -e HOST=0.0.0.0 \
   -e PORT=8000 \
+  -e MCP_AUTH_TOKEN=<a-strong-random-token> \
   -p 8000:8000 \
   netbox-mcp-server:latest
 ```
 
 > **Note:** Docker containers require `TRANSPORT=http` since stdio transport doesn't work in containerized environments.
+
+> **⚠️ Security:** The HTTP transport has **no authentication** unless you set `MCP_AUTH_TOKEN`. Binding to `HOST=0.0.0.0` exposes read access to all NetBox data your token can see to anyone who can reach the port. Set a strong `MCP_AUTH_TOKEN` (clients then send `Authorization: Bearer <token>`) and terminate TLS at a reverse proxy or gateway before exposing the server to a network. A bearer token sent over plain HTTP can be intercepted, so TLS is required for real deployments.
 
 **Connecting to NetBox on your host machine:**
 
@@ -321,6 +327,7 @@ docker run --rm \
   -e TRANSPORT=http \
   -e HOST=0.0.0.0 \
   -e PORT=8000 \
+  -e MCP_AUTH_TOKEN=<a-strong-random-token> \
   -p 8000:8000 \
   netbox-mcp-server:latest
 ```
@@ -335,6 +342,7 @@ docker run --rm \
   -e NETBOX_TOKEN=<your-api-token> \
   -e TRANSPORT=http \
   -e HOST=0.0.0.0 \
+  -e MCP_AUTH_TOKEN=<a-strong-random-token> \
   -e LOG_LEVEL=DEBUG \
   -e VERIFY_SSL=false \
   -p 8000:8000 \

--- a/src/netbox_mcp_server/config.py
+++ b/src/netbox_mcp_server/config.py
@@ -40,6 +40,16 @@ class Settings(BaseSettings):
         description="Browser origins allowed for HTTP CORS. Use * to allow any origin.",
     )
 
+    mcp_auth_token: SecretStr | None = Field(
+        default=None,
+        description=(
+            "Optional bearer token required on the HTTP transport endpoint. "
+            "When set, requests to the MCP endpoint must send "
+            "'Authorization: Bearer <token>'. Only applied when transport='http'."
+        ),
+    )
+    """Optional bearer token protecting the HTTP transport endpoint (treated as secret)"""
+
     # ===== Plugin Discovery Settings =====
     enable_plugin_discovery: bool = False
     """Whether to auto-discover plugin object types from NetBox at startup"""
@@ -69,6 +79,20 @@ class Settings(BaseSettings):
         """Ensure port is in valid range."""
         if not (0 < v < 65536):
             raise ValueError(f"Port must be between 1 and 65535, got {v}")
+        return v
+
+    @field_validator("mcp_auth_token", mode="after")
+    @classmethod
+    def normalize_auth_token(cls, v: SecretStr | None) -> SecretStr | None:
+        """Treat an empty or whitespace-only token as unset.
+
+        A present-but-empty value (e.g. an unpopulated container secret
+        rendering as MCP_AUTH_TOKEN=) would otherwise build a verifier that
+        accepts an empty bearer while the server logs that auth is enabled.
+        Normalizing to None here keeps every consumer in agreement.
+        """
+        if v is not None and not v.get_secret_value().strip():
+            return None
         return v
 
     @field_validator("netbox_url")
@@ -121,6 +145,7 @@ class Settings(BaseSettings):
                     "host": self.host,
                     "port": self.port,
                     "cors_origins": self.cors_origins,
+                    "mcp_auth_token": "***REDACTED***" if self.mcp_auth_token else None,
                 }
             )
         return summary

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -1,12 +1,15 @@
 import argparse
 import asyncio
+import hashlib
+import hmac
 import logging
 import sys
 from typing import Annotated, Any
 
 import httpx
 from fastmcp import FastMCP
-from pydantic import Field
+from fastmcp.server.auth import AccessToken, TokenVerifier
+from pydantic import Field, SecretStr
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 
@@ -61,6 +64,14 @@ def parse_cli_args() -> dict[str, Any]:
         action="append",
         help="CORS origins (repeat flag). Use * to allow any origin (default: none)",
     )
+    parser.add_argument(
+        "--mcp-auth-token",
+        type=str,
+        help=(
+            "Bearer token required on the HTTP transport endpoint "
+            "(prefer the MCP_AUTH_TOKEN env var; default: none)"
+        ),
+    )
 
     # Security settings
     ssl_group = parser.add_mutually_exclusive_group()
@@ -110,6 +121,8 @@ def parse_cli_args() -> dict[str, Any]:
         overlay["port"] = args.port
     if args.cors_origins is not None:
         overlay["cors_origins"] = args.cors_origins
+    if args.mcp_auth_token is not None:
+        overlay["mcp_auth_token"] = args.mcp_auth_token
     if args.verify_ssl is not None:
         overlay["verify_ssl"] = args.verify_ssl
     if args.enable_plugin_discovery is not None:
@@ -118,6 +131,52 @@ def parse_cli_args() -> dict[str, Any]:
         overlay["log_level"] = args.log_level
 
     return overlay
+
+
+class BearerTokenVerifier(TokenVerifier):
+    """Constant-time single-secret bearer check for the HTTP transport.
+
+    This is a FastMCP Resource Server verifier: it only validates an incoming
+    'Authorization: Bearer <token>' against one configured secret and issues no
+    tokens itself. FastMCP mounts its own auth middleware around this, returning
+    401 (+ WWW-Authenticate) for unauthenticated requests to the MCP endpoint.
+    """
+
+    def __init__(self, secret: str) -> None:
+        super().__init__()
+        # Digest, not raw secret: lets verify_token compare in constant time.
+        self._secret_digest = hashlib.sha256(secret.encode("utf-8")).digest()
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Return an AccessToken for a matching bearer, or None to reject."""
+        if not token:
+            return None
+        # Hash both sides: compare_digest raises TypeError on a non-ASCII str, and
+        # the bearer is attacker-controlled (header bytes decode as latin-1).
+        token_digest = hashlib.sha256(token.encode("utf-8", "surrogatepass")).digest()
+        if not hmac.compare_digest(token_digest, self._secret_digest):
+            return None
+        return AccessToken(token=token, client_id="netbox-mcp-server", scopes=[])
+
+
+def build_http_auth(token: SecretStr | None) -> TokenVerifier | None:
+    """
+    Build the HTTP transport auth provider from an optional bearer token.
+
+    Returns a verifier that makes FastMCP reject unauthenticated requests to the
+    MCP endpoint with 401, or None when no token is configured. Empty or
+    whitespace-only values are normalized to None upstream in Settings, so a
+    non-None token here is always a real secret.
+
+    Args:
+        token: Optional bearer token to require on the HTTP transport endpoint
+
+    Returns:
+        A TokenVerifier requiring the token, or None when no token is set
+    """
+    if token is None:
+        return None
+    return BearerTokenVerifier(token.get_secret_value())
 
 
 # Default object types for global search
@@ -728,6 +787,18 @@ def main() -> None:
             mcp.run(transport="stdio")
         elif settings.transport == "http":
             logger.info(f"Starting HTTP transport on {settings.host}:{settings.port}")
+            auth = build_http_auth(settings.mcp_auth_token)
+            if auth is not None:
+                # FastMCP reads mcp.auth when it builds the HTTP app at run time,
+                # so this assignment wires it (the 401 tests verify enforcement).
+                mcp.auth = auth
+                logger.info("HTTP transport authentication enabled (bearer token required)")
+            else:
+                logger.warning(
+                    "HTTP transport is running without authentication. Set "
+                    "MCP_AUTH_TOKEN, or place the server behind an authenticating "
+                    "TLS reverse proxy or gateway before exposing it to a network."
+                )
             middleware = [
                 Middleware(
                     CORSMiddleware,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,6 +60,55 @@ def test_settings_masks_secrets_in_summary():
     assert "super-secret-token" not in str(summary)
 
 
+# ===== MCP Auth Token Tests =====
+
+
+def test_auth_token_read_from_env():
+    """MCP_AUTH_TOKEN env var populates the secret field."""
+    with patch.dict(
+        "os.environ",
+        {
+            "NETBOX_URL": "https://netbox.example.com/",
+            "NETBOX_TOKEN": "tok",
+            "MCP_AUTH_TOKEN": "bearer-secret",
+        },
+        clear=True,
+    ):
+        settings = Settings(_env_file=None)
+
+    assert settings.mcp_auth_token is not None
+    assert settings.mcp_auth_token.get_secret_value() == "bearer-secret"
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_auth_token_normalized_to_none(blank):
+    """Empty or whitespace-only tokens are treated as unset (guards fail-open)."""
+    settings = Settings(
+        netbox_url="https://netbox.example.com/",
+        netbox_token="tok",
+        mcp_auth_token=blank,
+        _env_file=None,
+    )
+
+    assert settings.mcp_auth_token is None
+
+
+def test_auth_token_masked_in_summary():
+    """A configured auth token is redacted in the HTTP config summary."""
+    settings = Settings(
+        netbox_url="https://netbox.example.com/",
+        netbox_token="tok",
+        transport="http",
+        mcp_auth_token="bearer-secret",
+        _env_file=None,
+    )
+
+    summary = settings.get_effective_config_summary()
+
+    assert summary["mcp_auth_token"] == "***REDACTED***"
+    assert "bearer-secret" not in str(summary)
+
+
 # ===== CLI Argument Parsing Tests =====
 
 
@@ -86,6 +135,18 @@ def test_parse_cli_args_multiple():
         assert result["port"] == 9000
         assert result["log_level"] == "DEBUG"
         assert result["verify_ssl"] is False
+    finally:
+        sys.argv = original_argv
+
+
+def test_parse_cli_args_mcp_auth_token():
+    """--mcp-auth-token maps to the mcp_auth_token overlay key (typo guard)."""
+
+    original_argv = sys.argv
+    try:
+        sys.argv = ["server.py", "--mcp-auth-token", "bearer-secret"]
+        result = parse_cli_args()
+        assert result["mcp_auth_token"] == "bearer-secret"
     finally:
         sys.argv = original_argv
 

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -1,0 +1,89 @@
+"""Tests for optional Bearer token authentication on the HTTP transport.
+
+These verify the auth gate built by ``build_http_auth``: when a token is set,
+FastMCP rejects unauthenticated or mis-authenticated requests to the MCP
+endpoint with 401, and accepts requests carrying the correct token.
+"""
+
+import asyncio
+
+from fastmcp import FastMCP
+from pydantic import SecretStr
+from starlette.testclient import TestClient
+
+from netbox_mcp_server.server import build_http_auth
+
+TOKEN = "test-secret-token"
+
+_INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "test", "version": "1.0"},
+    },
+}
+_HEADERS = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+}
+
+
+def _make_client(token: SecretStr | None) -> TestClient:
+    """Build a TestClient for an MCP HTTP app, optionally protected by a token."""
+    mcp: FastMCP = FastMCP(name="test-netbox-mcp")
+
+    @mcp.tool
+    def ping() -> str:
+        return "pong"
+
+    auth = build_http_auth(token)
+    if auth is not None:
+        mcp.auth = auth
+    return TestClient(mcp.http_app())
+
+
+def test_request_without_token_is_rejected() -> None:
+    with _make_client(SecretStr(TOKEN)) as client:
+        response = client.post("/mcp/", json=_INITIALIZE, headers=_HEADERS)
+    assert response.status_code == 401
+
+
+def test_request_with_wrong_token_is_rejected() -> None:
+    headers = {**_HEADERS, "Authorization": "Bearer wrong-token"}
+    with _make_client(SecretStr(TOKEN)) as client:
+        response = client.post("/mcp/", json=_INITIALIZE, headers=headers)
+    assert response.status_code == 401
+
+
+def test_request_with_valid_token_is_accepted() -> None:
+    headers = {**_HEADERS, "Authorization": f"Bearer {TOKEN}"}
+    with _make_client(SecretStr(TOKEN)) as client:
+        response = client.post("/mcp/", json=_INITIALIZE, headers=headers)
+    assert response.status_code < 400
+
+
+def test_empty_bearer_rejected_when_token_configured() -> None:
+    headers = {**_HEADERS, "Authorization": "Bearer "}
+    with _make_client(SecretStr(TOKEN)) as client:
+        response = client.post("/mcp/", json=_INITIALIZE, headers=headers)
+    assert response.status_code == 401
+
+
+def test_unauthenticated_transport_allows_requests() -> None:
+    with _make_client(None) as client:
+        response = client.post("/mcp/", json=_INITIALIZE, headers=_HEADERS)
+    assert response.status_code != 401
+
+
+def test_non_ascii_bearer_is_rejected_not_errored() -> None:
+    # A non-ASCII bearer must be rejected, not raise (compare_digest rejects
+    # non-ASCII str). Driven directly: the httpx TestClient blocks such headers.
+    verifier = build_http_auth(SecretStr(TOKEN))
+    assert verifier is not None
+    assert asyncio.run(verifier.verify_token("\xff")) is None
+    assert asyncio.run(verifier.verify_token("caf\xe9")) is None
+    # Correct token still authenticates.
+    assert asyncio.run(verifier.verify_token(TOKEN)) is not None


### PR DESCRIPTION
Adds an optional `MCP_AUTH_TOKEN` for the HTTP transport. When set, requests to the MCP endpoint must present `Authorization: Bearer <token>`, verified in constant time via a `TokenVerifier` plugged into FastMCP's auth layer. Defaults are unchanged (stdio transport, `127.0.0.1` bind, no token), so existing deployments are unaffected; running HTTP without a token logs a warning at startup.

The README documents the option in the Docker examples and recommends terminating TLS at a reverse proxy or gateway when exposing the endpoint. Tests cover the 401/200 auth gate, empty/whitespace-token normalization, env and CLI wiring, and secret redaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
