### PR TITLE
enable sse transport option

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The server supports multiple configuration sources with the following precedence
 |---------|------|---------|----------|-------------|
 | `NETBOX_URL` | URL | - | Yes | Base URL of your NetBox instance (e.g., https://netbox.example.com/) |
 | `NETBOX_TOKEN` | String | - | Yes | API token for authentication |
-| `TRANSPORT` | `stdio` \| `http` | `stdio` | No | MCP transport protocol |
+| `TRANSPORT` | `stdio` \| `http` \| `sse` | `stdio` | No | MCP transport protocol |
 | `HOST` | String | `127.0.0.1` | If HTTP | Host address for HTTP server |
 | `PORT` | Integer | `8000` | If HTTP | Port for HTTP server |
 | `MCP_AUTH_TOKEN` | String | - | No | Bearer token required on the HTTP endpoint. When unset, the HTTP transport is unauthenticated. Clients send `Authorization: Bearer <token>`. |

--- a/src/netbox_mcp_server/config.py
+++ b/src/netbox_mcp_server/config.py
@@ -26,14 +26,14 @@ class Settings(BaseSettings):
     """API token for NetBox authentication (treated as secret)"""
 
     # ===== Transport Settings =====
-    transport: Literal["stdio", "http"] = "stdio"
+    transport: Literal["stdio", "http", "sse"] = "stdio"
     """MCP transport protocol to use (stdio for Claude Desktop, http for web clients)"""
 
     host: str = "127.0.0.1"
-    """Host address to bind HTTP server (only used when transport='http')"""
+    """Host address to bind HTTP server (only used when transport='http/sse')"""
 
     port: int = 8000
-    """Port to bind HTTP server (only used when transport='http')"""
+    """Port to bind HTTP server (only used when transport='http/sse')"""
 
     cors_origins: list[str] = Field(
         default_factory=list,

--- a/src/netbox_mcp_server/server.py
+++ b/src/netbox_mcp_server/server.py
@@ -46,7 +46,7 @@ def parse_cli_args() -> dict[str, Any]:
     parser.add_argument(
         "--transport",
         type=str,
-        choices=["stdio", "http"],
+        choices=["stdio", "http", "sse"],
         help="MCP transport protocol (default: stdio)",
     )
     parser.add_argument(
@@ -785,6 +785,9 @@ def main() -> None:
         if settings.transport == "stdio":
             logger.info("Starting stdio transport")
             mcp.run(transport="stdio")
+        elif settings.transport == "sse":
+            logger.info(f"Starting SSE transport on {settings.host}:{settings.port}")
+            mcp.run(transport="sse", host=settings.host, port=settings.port)
         elif settings.transport == "http":
             logger.info(f"Starting HTTP transport on {settings.host}:{settings.port}")
             auth = build_http_auth(settings.mcp_auth_token)


### PR DESCRIPTION
## Summary

This PR adds support for the `sse` transport alongside the existing `stdio` and `http` transports.

### Motivation

I've been using this MCP server with Claude Desktop, connecting to a remotely hosted NetBox MCP server. In my setup, I ran into connectivity issues when using the HTTP transport, while the SSE transport has been reliable.

Adding SSE as a transport option allows this deployment model without changing the existing behavior for `stdio` or `http` users.

> **Note:** I realize that SSE is considered a legacy transport in the evolving MCP ecosystem. However, it is still supported by MCP clients and has proven to be a practical option for my remote deployment scenario.

### Changes

* Add `sse` as a valid transport option in the configuration and CLI.
* Start the MCP server using the SSE transport when selected.
* Update the README to document the new transport option.

This change is fully opt-in and does not affect existing users unless they explicitly choose `TRANSPORT=sse`.